### PR TITLE
docs: update macOS source setup notes (tauri-cli, submodule, cmake)

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,15 +70,16 @@ Requirements: Node.js 20+, pnpm, Rust stable.
 ```bash
 # macOS system deps
 xcode-select --install
-brew install nasm pkg-config autoconf automake libtool
+brew install nasm pkg-config autoconf automake libtool cmake
 
 # Linux system deps (Ubuntu/Debian)
 # sudo apt install libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev \
-#   patchelf nasm clang pkg-config autoconf automake libtool
+#   patchelf nasm clang pkg-config autoconf automake libtool cmake
 
 # Clone and build
 git clone --recursive https://github.com/julyx10/lap.git
 cd lap
+git submodule update --init --recursive
 cargo install tauri-cli --version "^2.0.0" --locked
 ./scripts/download_models.sh            # Windows: .\scripts\download_models.ps1
 cd src-vite && pnpm install && cd ..


### PR DESCRIPTION

Hi @julyx10, thank you for this project.

I needed a program like this, and Lap is exactly what I was looking for — the UI is clean, and features like face recognition and editing work really well. I'd love to keep contributing if I can.

I couldn't find a contributing guide, so I opened this PR to `main`. If this is not the right process, please let me know.

## Changes

Added missing steps for building from source on macOS (Apple Silicon):

- `cargo install tauri-cli` — needed before `cargo tauri dev`
- `git submodule update --init --recursive` — third-party submodules (LibRaw, libjpeg-turbo) were not initialized
- `cmake` in Homebrew dependencies — required by libjpeg-turbo submodule build

## Note

I also hit a linker issue after macOS software update (CLT clang changed from 17 to 21):

- `ld: warning: search path '/Library/Developer/CommandLineTools/usr/lib/clang/17/lib/darwin' not found`
- `ld: library 'clang_rt.osx' not found`

At first I thought my Rust install or OS setup was wrong, but later I found `target/debug/build/ort-sys-*/output` still referenced clang 17. After clearing cache, build worked:

```bash
rm -rf target/debug/build/ort-sys-*
rm -rf ~/Library/Caches/ort.pyke.io
```

Because this seemed like a local cache/toolchain mismatch, I did not include this in the README.

Thanks for reviewing.
