### PR TITLE
Add configurable library metadata storage directories

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -63,6 +63,9 @@ async fn main() {
         .manage(t_cmds::IndexCancellation(std::sync::Arc::new(
             std::sync::Mutex::new(std::collections::HashMap::new()),
         )))
+        .manage(t_cmds::IndexActivity(std::sync::Arc::new(
+            std::sync::Mutex::new(std::collections::HashMap::new()),
+        )))
         .manage(t_face::FaceIndexCancellation(std::sync::Arc::new(
             std::sync::Mutex::new(false),
         )))
@@ -147,6 +150,8 @@ async fn main() {
             t_cmds::hide_library,
             t_cmds::reorder_libraries,
             t_cmds::switch_library,
+            t_cmds::move_library_storage,
+            t_cmds::cancel_library_storage_move,
             t_cmds::get_library_info,
             t_cmds::save_library_state,
             t_cmds::get_library_state,
@@ -162,6 +167,7 @@ async fn main() {
             t_cmds::set_album_cover,
             t_cmds::index_album,
             t_cmds::cancel_indexing,
+            t_cmds::get_indexing_activity,
             t_cmds::get_index_recovery_info,
             t_cmds::clear_index_recovery_info,
             // folder

--- a/src-tauri/src/t_cmds.rs
+++ b/src-tauri/src/t_cmds.rs
@@ -14,14 +14,26 @@ use crate::t_sqlite::{
 use crate::t_utils;
 use crate::{t_ai, t_sqlite};
 
+use serde::Serialize;
 use std::collections::HashMap;
 use std::path::Path;
 use std::process::Command;
+use std::sync::atomic::Ordering;
 use std::sync::{Arc, Mutex};
 use tauri::State;
 
 // cancellation token for indexing
 pub struct IndexCancellation(pub Arc<Mutex<HashMap<i64, bool>>>);
+
+// active indexing workers
+pub struct IndexActivity(pub Arc<Mutex<HashMap<i64, usize>>>);
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct IndexingActivity {
+    pub running: bool,
+    pub album_id: Option<i64>,
+}
 
 // build info
 include!(concat!(env!("OUT_DIR"), "/build_info.rs"));
@@ -36,39 +48,101 @@ pub fn get_app_config() -> Result<AppConfig, String> {
 
 #[tauri::command]
 pub fn add_library(name: &str) -> Result<Library, String> {
+    ensure_library_storage_mutation_allowed()?;
     t_config::add_library(name)
 }
 
 /// hide a library
 #[tauri::command]
 pub fn hide_library(id: &str, hidden: bool) -> Result<(), String> {
+    ensure_library_storage_mutation_allowed()?;
     t_config::hide_library(id, hidden)
 }
 
 /// reorder libraries
 #[tauri::command]
 pub fn reorder_libraries(ids: Vec<String>) -> Result<(), String> {
+    ensure_library_storage_mutation_allowed()?;
     t_config::reorder_libraries(ids)
 }
 
 /// edit library name
 #[tauri::command]
 pub fn edit_library(id: &str, name: &str) -> Result<(), String> {
+    ensure_library_storage_mutation_allowed()?;
     t_config::edit_library(id, name)
 }
 
 /// remove a library (also deletes the database file)
 #[tauri::command]
 pub fn remove_library(id: &str) -> Result<(), String> {
+    ensure_library_storage_mutation_allowed()?;
     t_config::remove_library(id)
 }
 
 /// switch to a different library
 #[tauri::command]
 pub fn switch_library(app_handle: tauri::AppHandle, id: &str) -> Result<(), String> {
+    ensure_library_storage_mutation_allowed()?;
+    t_sqlite::create_db_for_library(id)?;
     t_config::switch_library(id)?;
-    t_sqlite::create_db()?;
     t_utils::restore_album_scopes(&app_handle)
+}
+
+/// move a library database to a different storage directory
+#[tauri::command]
+pub async fn move_library_storage(
+    app_handle: tauri::AppHandle,
+    index_activity_state: State<'_, IndexActivity>,
+    dedup_state: State<'_, crate::t_dedup::DedupState>,
+    face_status_state: State<'_, t_face::FaceIndexingStatus>,
+    id: String,
+    storage_dir: Option<String>,
+) -> Result<LibraryInfo, String> {
+    ensure_library_storage_move_idle(&index_activity_state, &dedup_state, &face_status_state)?;
+    tauri::async_runtime::spawn_blocking(move || {
+        t_config::move_library_storage(&app_handle, &id, storage_dir)
+    })
+    .await
+    .map_err(|e| format!("Failed to join library storage move task: {}", e))?
+}
+
+fn ensure_library_storage_move_idle(
+    index_activity_state: &State<'_, IndexActivity>,
+    dedup_state: &State<'_, crate::t_dedup::DedupState>,
+    face_status_state: &State<'_, t_face::FaceIndexingStatus>,
+) -> Result<(), String> {
+    let indexing_running = !index_activity_state.0.lock().unwrap().is_empty();
+    let dedup_running = dedup_state.is_scanning.load(Ordering::SeqCst);
+    let face_running = *face_status_state.0.lock().unwrap();
+
+    if indexing_running || dedup_running || face_running {
+        return Err(
+            "Cannot move library storage while indexing, dedup, or face indexing is still running."
+                .to_string(),
+        );
+    }
+
+    Ok(())
+}
+
+fn ensure_library_storage_mutation_allowed() -> Result<(), String> {
+    t_config::ensure_library_storage_write_allowed()
+}
+
+fn ensure_library_storage_mutation_allowed_or_none() -> bool {
+    match ensure_library_storage_mutation_allowed() {
+        Ok(_) => true,
+        Err(error) => {
+            eprintln!("{}", error);
+            false
+        }
+    }
+}
+
+#[tauri::command]
+pub fn cancel_library_storage_move(id: &str) -> Result<(), String> {
+    t_config::cancel_library_storage_move(id)
 }
 
 /// get library statistics
@@ -82,6 +156,7 @@ pub async fn get_library_info(id: String) -> Result<LibraryInfo, String> {
 /// save library state
 #[tauri::command]
 pub fn save_library_state(id: &str, state: LibraryState) -> Result<(), String> {
+    ensure_library_storage_mutation_allowed()?;
     t_config::save_library_state(id, state)
 }
 
@@ -114,12 +189,14 @@ pub fn get_album(album_id: i64) -> Result<Album, String> {
 /// recount files for an album and return updated album
 #[tauri::command]
 pub fn recount_album(album_id: i64) -> Result<Album, String> {
+    ensure_library_storage_mutation_allowed()?;
     Album::recount_album(album_id).map_err(|e| format!("Error while recounting album: {}", e))
 }
 
 /// add an album
 #[tauri::command]
 pub fn add_album(app_handle: tauri::AppHandle, folder_path: &str) -> Result<Album, String> {
+    ensure_library_storage_mutation_allowed()?;
     t_utils::authorize_directory_scope(&app_handle, folder_path).map_err(|e| {
         format!(
             "Error while authorizing album folder '{}': {}",
@@ -134,6 +211,7 @@ pub fn add_album(app_handle: tauri::AppHandle, folder_path: &str) -> Result<Albu
 /// edit an album
 #[tauri::command]
 pub fn edit_album(id: i64, name: &str, description: &str) -> Result<usize, String> {
+    ensure_library_storage_mutation_allowed()?;
     let _ = Album::update_column(id, "name", &name)
         .map_err(|e| format!("Error while editing album with id {}: {}", id, e));
 
@@ -144,6 +222,7 @@ pub fn edit_album(id: i64, name: &str, description: &str) -> Result<usize, Strin
 /// remove an album
 #[tauri::command]
 pub fn remove_album(id: i64) -> Result<usize, String> {
+    ensure_library_storage_mutation_allowed()?;
     Album::delete_from_db(id)
         .map_err(|e| format!("Error while removing album with id {}: {}", id, e))
 }
@@ -151,6 +230,7 @@ pub fn remove_album(id: i64) -> Result<usize, String> {
 /// set album display order
 #[tauri::command]
 pub fn set_album_display_order(id: i64, display_order: i32) -> Result<usize, String> {
+    ensure_library_storage_mutation_allowed()?;
     Album::update_column(id, "display_order_id", &display_order)
         .map_err(|e| format!("Error while setting album display order: {}", e))
 }
@@ -158,6 +238,7 @@ pub fn set_album_display_order(id: i64, display_order: i32) -> Result<usize, Str
 /// set album cover
 #[tauri::command]
 pub fn set_album_cover(id: i64, file_id: i64) -> Result<usize, String> {
+    ensure_library_storage_mutation_allowed()?;
     Album::update_column(id, "cover_file_id", &file_id)
         .map_err(|e| format!("Error while setting album cover: {}", e))
 }
@@ -167,13 +248,21 @@ pub fn set_album_cover(id: i64, file_id: i64) -> Result<usize, String> {
 pub fn index_album(
     app_handle: tauri::AppHandle,
     state: State<IndexCancellation>,
+    activity_state: State<IndexActivity>,
     album_id: i64,
     thumbnail_size: u32,
     skip_file_path: Option<String>,
 ) -> Result<(), String> {
+    ensure_library_storage_mutation_allowed()?;
     // Reset cancellation flag
     state.0.lock().unwrap().insert(album_id, false);
     let cancellation_token = state.0.clone();
+    let cancellation_cleanup_token = state.0.clone();
+    {
+        let mut activity = activity_state.0.lock().unwrap();
+        *activity.entry(album_id).or_insert(0) += 1;
+    }
+    let activity_token = activity_state.0.clone();
 
     tauri::async_runtime::spawn(async move {
         if let Err(e) = t_utils::index_album_worker(
@@ -187,6 +276,15 @@ pub fn index_album(
         {
             eprintln!("Error indexing album {}: {}", album_id, e);
         }
+        cancellation_cleanup_token.lock().unwrap().remove(&album_id);
+        let mut activity = activity_token.lock().unwrap();
+        if let Some(count) = activity.get_mut(&album_id) {
+            if *count <= 1 {
+                activity.remove(&album_id);
+            } else {
+                *count -= 1;
+            }
+        }
     });
     Ok(())
 }
@@ -196,6 +294,16 @@ pub fn index_album(
 pub fn cancel_indexing(state: State<IndexCancellation>, album_id: i64) -> Result<(), String> {
     state.0.lock().unwrap().insert(album_id, true);
     Ok(())
+}
+
+#[tauri::command]
+pub fn get_indexing_activity(state: State<IndexActivity>) -> Result<IndexingActivity, String> {
+    let activity = state.0.lock().unwrap();
+    let album_id = activity.keys().next().copied();
+    Ok(IndexingActivity {
+        running: !activity.is_empty(),
+        album_id,
+    })
 }
 
 #[tauri::command]
@@ -218,6 +326,7 @@ pub fn select_folder(
     album_id: i64,
     folder_path: &str,
 ) -> Result<AFolder, String> {
+    ensure_library_storage_mutation_allowed()?;
     t_utils::authorize_directory_scope(&app_handle, folder_path)
         .map_err(|e| format!("Error while authorizing folder '{}': {}", folder_path, e))?;
 
@@ -247,6 +356,9 @@ pub fn create_folder(path: &str, folder_name: &str) -> Option<String> {
 /// rename a folder
 #[tauri::command]
 pub fn rename_folder(folder_path: &str, new_folder_name: &str) -> Option<String> {
+    if !ensure_library_storage_mutation_allowed_or_none() {
+        return None;
+    }
     let new_folder_path = t_utils::rename_folder(folder_path, new_folder_name);
 
     match new_folder_path {
@@ -264,6 +376,9 @@ pub fn rename_folder(folder_path: &str, new_folder_name: &str) -> Option<String>
 /// move a folder
 #[tauri::command]
 pub fn move_folder(folder_path: &str, new_album_id: i64, new_folder_path: &str) -> Option<String> {
+    if !ensure_library_storage_mutation_allowed_or_none() {
+        return None;
+    }
     // Move the folder in the file system
     let result = t_utils::move_folder(folder_path, new_folder_path);
 
@@ -287,6 +402,7 @@ pub fn copy_folder(folder_path: &str, new_folder_path: &str) -> Option<String> {
 /// delete a folder
 #[tauri::command]
 pub fn delete_folder(folder_path: &str) -> Result<usize, String> {
+    ensure_library_storage_mutation_allowed()?;
     // trash the folder
     trash::delete(folder_path).map_err(|e| e.to_string())?;
 
@@ -435,6 +551,9 @@ pub async fn copy_image(file_path: String) -> Result<bool, String> {
 /// rename a file
 #[tauri::command]
 pub fn rename_file(file_id: i64, file_path: &str, new_name: &str) -> Option<String> {
+    if !ensure_library_storage_mutation_allowed_or_none() {
+        return None;
+    }
     match t_utils::rename_file(file_path, new_name) {
         Some(new_file_path) => {
             let name_pinyin = t_utils::convert_to_pinyin(new_name);
@@ -463,6 +582,9 @@ pub fn move_file(
     new_folder_id: i64,
     new_folder_path: &str,
 ) -> Option<String> {
+    if !ensure_library_storage_mutation_allowed_or_none() {
+        return None;
+    }
     let moved_file = t_utils::move_file(file_path, new_folder_path);
     match moved_file {
         Some(new_path) => {
@@ -484,6 +606,7 @@ pub fn copy_file(file_path: &str, new_folder_path: &str) -> Option<String> {
 /// delete a file
 #[tauri::command]
 pub fn delete_file(file_id: i64, file_path: &str) -> Result<usize, String> {
+    ensure_library_storage_mutation_allowed()?;
     // trash the file
     trash::delete(file_path).map_err(|e| e.to_string())?;
 
@@ -494,6 +617,7 @@ pub fn delete_file(file_id: i64, file_path: &str) -> Result<usize, String> {
 /// delete a file from db
 #[tauri::command]
 pub fn delete_db_file(file_id: i64) -> Result<usize, String> {
+    ensure_library_storage_mutation_allowed()?;
     // delete the file from db
     AFile::delete(file_id).map_err(|e| format!("Error while deleting file from DB: {}", e))
 }
@@ -501,6 +625,7 @@ pub fn delete_db_file(file_id: i64) -> Result<usize, String> {
 /// edit a file's comment
 #[tauri::command]
 pub fn edit_file_comment(file_id: i64, comment: &str) -> Result<usize, String> {
+    ensure_library_storage_mutation_allowed()?;
     AFile::update_column(file_id, "comments", &comment)
         .map_err(|e| format!("Error while editing file comment: {}", e))
 }
@@ -515,6 +640,7 @@ pub async fn get_file_thumb(
     thumbnail_size: u32,
     force_regenerate: bool,
 ) -> Result<Option<AThumb>, String> {
+    ensure_library_storage_mutation_allowed()?;
     AThumb::get_or_create_thumb(
         file_id,
         file_path,
@@ -535,6 +661,7 @@ pub fn get_file_info(file_id: i64) -> Result<Option<AFile>, String> {
 /// update a file's info
 #[tauri::command]
 pub fn update_file_info(file_id: i64, file_path: &str) -> Result<Option<AFile>, String> {
+    ensure_library_storage_mutation_allowed()?;
     AFile::update_file_info(file_id, file_path)
         .map_err(|e| format!("Error while updating file info: {}", e))
 }
@@ -542,6 +669,7 @@ pub fn update_file_info(file_id: i64, file_path: &str) -> Result<Option<AFile>, 
 /// add or refresh a file in db and return the indexed file info
 #[tauri::command]
 pub fn add_file_to_db(folder_id: i64, file_path: &str) -> Result<Option<AFile>, String> {
+    ensure_library_storage_mutation_allowed()?;
     let file_type = t_utils::get_file_type(file_path)
         .ok_or_else(|| format!("Unsupported file type: {}", file_path))?;
     let (file, _) = AFile::add_to_db(folder_id, file_path, file_type)?;
@@ -557,6 +685,7 @@ pub fn check_file_exists(file_path: &str) -> bool {
 /// set a file's rotate status
 #[tauri::command]
 pub fn set_file_rotate(file_id: i64, rotate: i32) -> Result<usize, String> {
+    ensure_library_storage_mutation_allowed()?;
     AFile::update_column(file_id, "rotate", &rotate)
         .map_err(|e| format!("Error while setting file rotate: {}", e))
 }
@@ -592,6 +721,7 @@ pub fn get_folder_favorite(folder_path: &str) -> Result<bool, String> {
 /// set a folder's favorite status (true or false)
 #[tauri::command]
 pub fn set_folder_favorite(folder_id: i64, is_favorite: bool) -> Result<usize, String> {
+    ensure_library_storage_mutation_allowed()?;
     AFolder::update_column(folder_id, "is_favorite", &is_favorite)
         .map_err(|e| format!("Error while setting folder favorite: {}", e))
 }
@@ -599,6 +729,7 @@ pub fn set_folder_favorite(folder_id: i64, is_favorite: bool) -> Result<usize, S
 /// set a file's favorite status (true or false)
 #[tauri::command]
 pub fn set_file_favorite(file_id: i64, is_favorite: bool) -> Result<usize, String> {
+    ensure_library_storage_mutation_allowed()?;
     AFile::update_column(file_id, "is_favorite", &is_favorite)
         .map_err(|e| format!("Error while setting file favorite: {}", e))
 }
@@ -606,6 +737,7 @@ pub fn set_file_favorite(file_id: i64, is_favorite: bool) -> Result<usize, Strin
 /// set a file's rating (0-5)
 #[tauri::command]
 pub fn set_file_rating(file_id: i64, rating: i32) -> Result<usize, String> {
+    ensure_library_storage_mutation_allowed()?;
     let clamped = rating.clamp(0, 5);
     AFile::update_column(file_id, "rating", &clamped)
         .map_err(|e| format!("Error while setting file rating: {}", e))
@@ -628,18 +760,21 @@ pub fn get_tag_name(tag_id: i64) -> Result<String, String> {
 /// create a new tag
 #[tauri::command]
 pub fn create_tag(name: &str) -> Result<ATag, String> {
+    ensure_library_storage_mutation_allowed()?;
     ATag::add(name).map_err(|e| format!("Error while creating tag: {}", e))
 }
 
 /// rename a tag
 #[tauri::command]
 pub fn rename_tag(tag_id: i64, new_name: &str) -> Result<usize, String> {
+    ensure_library_storage_mutation_allowed()?;
     ATag::rename(tag_id, new_name).map_err(|e| format!("Error while renaming tag: {}", e))
 }
 
 /// delete a tag
 #[tauri::command]
 pub fn delete_tag(tag_id: i64) -> Result<usize, String> {
+    ensure_library_storage_mutation_allowed()?;
     ATag::delete(tag_id).map_err(|e| format!("Error while deleting tag: {}", e))
 }
 
@@ -653,6 +788,7 @@ pub fn get_tags_for_file(file_id: i64) -> Result<Vec<ATag>, String> {
 /// add a tag to a file
 #[tauri::command]
 pub fn add_tag_to_file(file_id: i64, tag_id: i64) -> Result<(), String> {
+    ensure_library_storage_mutation_allowed()?;
     ATag::add_tag_to_file(file_id, tag_id)
         .map_err(|e| format!("Error while adding tag to file: {}", e))
 }
@@ -660,6 +796,7 @@ pub fn add_tag_to_file(file_id: i64, tag_id: i64) -> Result<(), String> {
 /// remove a tag from a file
 #[tauri::command]
 pub fn remove_tag_from_file(file_id: i64, tag_id: i64) -> Result<usize, String> {
+    ensure_library_storage_mutation_allowed()?;
     ATag::remove_tag_from_file(file_id, tag_id)
         .map_err(|e| format!("Error while removing tag from file: {}", e))
 }
@@ -732,6 +869,7 @@ pub fn check_ai_status(state: State<t_ai::AiState>) -> String {
 /// generate embedding for a file
 #[tauri::command]
 pub fn generate_embedding(state: State<t_ai::AiState>, file_id: i64) -> Result<String, String> {
+    ensure_library_storage_mutation_allowed()?;
     AFile::generate_embedding(&state, file_id)
 }
 
@@ -757,6 +895,7 @@ pub fn index_faces(
     progress_state: State<t_face::FaceIndexProgressState>,
     cluster_epsilon: Option<f32>,
 ) -> Result<(), String> {
+    ensure_library_storage_mutation_allowed()?;
     t_face::run_face_indexing(
         app_handle,
         (*state).clone(),
@@ -792,6 +931,7 @@ pub fn cancel_face_index(state: State<t_face::FaceIndexCancellation>) -> Result<
 /// reset all faces (delete all faces and persons)
 #[tauri::command]
 pub fn reset_faces() -> Result<(), String> {
+    ensure_library_storage_mutation_allowed()?;
     t_sqlite::Face::reset_all().map_err(|e| format!("Error while resetting faces: {}", e))
 }
 
@@ -819,12 +959,14 @@ pub fn get_persons() -> Result<Vec<Person>, String> {
 /// rename a person
 #[tauri::command]
 pub fn rename_person(person_id: i64, name: String) -> Result<usize, String> {
+    ensure_library_storage_mutation_allowed()?;
     Person::rename(person_id, &name).map_err(|e| format!("Error while renaming person: {}", e))
 }
 
 /// delete a person
 #[tauri::command]
 pub fn delete_person(person_id: i64) -> Result<usize, String> {
+    ensure_library_storage_mutation_allowed()?;
     Person::delete(person_id).map_err(|e| format!("Error while deleting person: {}", e))
 }
 
@@ -845,6 +987,7 @@ pub fn dedup_start_scan(
     state: tauri::State<'_, crate::t_dedup::DedupState>,
     params: Option<crate::t_sqlite::QueryParams>,
 ) -> Result<(), String> {
+    ensure_library_storage_mutation_allowed()?;
     crate::t_dedup::start_scan(app_handle, state, params)
 }
 
@@ -888,6 +1031,7 @@ pub fn dedup_get_group(group_id: i64) -> Result<crate::t_dedup::DedupGroup, Stri
 
 #[tauri::command]
 pub fn dedup_set_keep(group_id: i64, file_id: i64) -> Result<(), String> {
+    ensure_library_storage_mutation_allowed()?;
     crate::t_dedup::set_keep(group_id, file_id)
 }
 
@@ -896,5 +1040,6 @@ pub fn dedup_delete_selected(
     group_ids: Option<Vec<i64>>,
     file_ids: Option<Vec<i64>>,
 ) -> Result<(), String> {
+    ensure_library_storage_mutation_allowed()?;
     crate::t_dedup::delete_selected(group_ids, file_ids)
 }

--- a/src-tauri/src/t_config.rs
+++ b/src-tauri/src/t_config.rs
@@ -7,15 +7,23 @@
  */
 use serde::{Deserialize, Serialize};
 use std::fs;
-use std::io::Write;
+use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 use std::sync::{Mutex, OnceLock};
 use std::thread;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use tauri::Emitter;
 use uuid::Uuid;
 
 static APP_IDENTIFIER: OnceLock<String> = OnceLock::new();
 static CONFIG_IO_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+static STORAGE_MOVE_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+static LIBRARY_STORAGE_MOVE_STATE: OnceLock<Mutex<LibraryStorageMoveState>> = OnceLock::new();
+static APP_DATA_DIR_OVERRIDE: OnceLock<Mutex<Option<PathBuf>>> = OnceLock::new();
+#[cfg(test)]
+static CONFIG_WRITE_FAIL_OVERRIDE: OnceLock<Mutex<bool>> = OnceLock::new();
+
+pub const LIBRARY_STORAGE_MOVE_IN_PROGRESS_ERROR: &str = "Library storage move in progress.";
 
 pub fn set_app_identifier(identifier: &str) {
     let _ = APP_IDENTIFIER.set(identifier.to_string());
@@ -23,6 +31,38 @@ pub fn set_app_identifier(identifier: &str) {
 
 fn config_io_lock() -> &'static Mutex<()> {
     CONFIG_IO_LOCK.get_or_init(|| Mutex::new(()))
+}
+
+fn storage_move_lock() -> &'static Mutex<()> {
+    STORAGE_MOVE_LOCK.get_or_init(|| Mutex::new(()))
+}
+
+fn storage_move_state() -> &'static Mutex<LibraryStorageMoveState> {
+    LIBRARY_STORAGE_MOVE_STATE.get_or_init(|| Mutex::new(LibraryStorageMoveState::default()))
+}
+
+fn app_data_dir_override() -> &'static Mutex<Option<PathBuf>> {
+    APP_DATA_DIR_OVERRIDE.get_or_init(|| Mutex::new(None))
+}
+
+#[cfg(test)]
+fn config_write_fail_override() -> &'static Mutex<bool> {
+    CONFIG_WRITE_FAIL_OVERRIDE.get_or_init(|| Mutex::new(false))
+}
+
+#[cfg(test)]
+fn should_fail_config_write() -> bool {
+    config_write_fail_override()
+        .lock()
+        .map(|flag| *flag)
+        .unwrap_or(false)
+}
+
+#[cfg(test)]
+pub(crate) fn set_test_config_write_failure(enabled: bool) {
+    if let Ok(mut flag) = config_write_fail_override().lock() {
+        *flag = enabled;
+    }
 }
 
 // ============================================================================
@@ -215,6 +255,10 @@ pub struct Library {
     pub state: LibraryState,
     #[serde(default)]
     pub hidden: bool,
+    #[serde(default)]
+    pub storage_dir: Option<String>,
+    #[serde(default)]
+    pub metadata_initialized: bool,
 }
 
 /// App configuration stored in app-config.json
@@ -238,6 +282,8 @@ impl Default for AppConfig {
                 created_at: now,
                 state: LibraryState::default(),
                 hidden: false,
+                storage_dir: None,
+                metadata_initialized: false,
             }],
         }
     }
@@ -245,6 +291,12 @@ impl Default for AppConfig {
 
 /// Get the AppData directory for app
 pub fn get_app_data_dir() -> Result<PathBuf, String> {
+    if let Ok(override_dir) = app_data_dir_override().lock() {
+        if let Some(path) = override_dir.as_ref() {
+            return Ok(path.clone());
+        }
+    }
+
     let app_dir_name = get_app_data_folder_name();
     dirs::data_local_dir()
         .ok_or_else(|| "Failed to get the local AppData directory".to_string())
@@ -262,6 +314,136 @@ fn get_app_data_folder_name() -> String {
     } else {
         identifier
     }
+}
+
+fn normalize_storage_dir_value(storage_dir: Option<String>) -> Option<String> {
+    storage_dir.and_then(|dir| {
+        let trimmed = dir.trim();
+        if trimmed.is_empty() {
+            None
+        } else {
+            Some(trimmed.to_string())
+        }
+    })
+}
+
+fn canonicalize_existing_directory(path: &Path, label: &str) -> Result<PathBuf, String> {
+    if !path.is_absolute() {
+        return Err(format!(
+            "{} must be an absolute path: {}",
+            label,
+            path.display()
+        ));
+    }
+
+    if !path.exists() {
+        return Err(format!("{} does not exist: {}", label, path.display()));
+    }
+
+    if !path.is_dir() {
+        return Err(format!("{} is not a directory: {}", label, path.display()));
+    }
+
+    fs::canonicalize(path).map_err(|e| {
+        format!(
+            "Failed to canonicalize {} '{}': {}",
+            label,
+            path.display(),
+            e
+        )
+    })
+}
+
+fn canonicalize_custom_storage_dir(storage_dir: Option<String>) -> Result<Option<String>, String> {
+    match normalize_storage_dir_value(storage_dir) {
+        Some(dir) => {
+            let canonical =
+                canonicalize_existing_directory(Path::new(&dir), "Target storage directory")?;
+            Ok(Some(canonical.to_string_lossy().into_owned()))
+        }
+        None => Ok(None),
+    }
+}
+
+fn get_effective_storage_dir(library: &Library) -> Result<(PathBuf, bool), String> {
+    match normalize_storage_dir_value(library.storage_dir.clone()) {
+        Some(dir) => Ok((PathBuf::from(dir), false)),
+        None => Ok((get_libraries_dir()?, true)),
+    }
+}
+
+fn ensure_storage_dir_ready(library: &Library) -> Result<PathBuf, String> {
+    let (dir, uses_default) = get_effective_storage_dir(library)?;
+
+    if uses_default {
+        fs::create_dir_all(&dir).map_err(|e| {
+            format!(
+                "Failed to create default libraries directory '{}': {}",
+                dir.display(),
+                e
+            )
+        })?;
+        return Ok(dir);
+    }
+
+    if !dir.exists() {
+        return Err(format!(
+            "Library storage directory is unavailable: {}",
+            dir.display()
+        ));
+    }
+
+    if !dir.is_dir() {
+        return Err(format!(
+            "Library storage path is not a directory: {}",
+            dir.display()
+        ));
+    }
+
+    Ok(dir)
+}
+
+fn is_storage_dir_available(library: &Library) -> Result<bool, String> {
+    let (dir, uses_default) = get_effective_storage_dir(library)?;
+    if uses_default {
+        return Ok(true);
+    }
+
+    Ok(dir.exists() && dir.is_dir())
+}
+
+fn library_has_metadata_files(library: &Library) -> Result<bool, String> {
+    if !is_storage_dir_available(library)? {
+        return Ok(false);
+    }
+
+    let db_path = library_db_path_from_library(library)?;
+    Ok(!existing_sqlite_files(&db_path).is_empty())
+}
+
+fn library_effective_metadata_initialized(library: &Library) -> Result<bool, String> {
+    if library.metadata_initialized {
+        return Ok(true);
+    }
+
+    library_has_metadata_files(library)
+}
+
+fn library_allows_disconnected_metadata_operation(library: &Library) -> Result<bool, String> {
+    Ok(!library_effective_metadata_initialized(library)?)
+}
+
+fn library_db_path_from_library(library: &Library) -> Result<PathBuf, String> {
+    let (dir, _) = get_effective_storage_dir(library)?;
+    Ok(dir.join(format!("{}.db", library.id)))
+}
+
+fn find_library<'a>(config: &'a AppConfig, library_id: &str) -> Result<&'a Library, String> {
+    config
+        .libraries
+        .iter()
+        .find(|library| library.id == library_id)
+        .ok_or_else(|| "Library not found".to_string())
 }
 
 /// Get the libraries directory path
@@ -355,6 +537,45 @@ pub fn save_app_config(config: &AppConfig) -> Result<(), String> {
     save_app_config_locked(config)
 }
 
+fn update_app_config<R, F>(mutator: F) -> Result<R, String>
+where
+    F: FnOnce(&mut AppConfig) -> Result<R, String>,
+{
+    let _guard = config_io_lock()
+        .lock()
+        .map_err(|_| "Config lock poisoned".to_string())?;
+    let mut config = load_app_config_locked()?;
+    let result = mutator(&mut config)?;
+    save_app_config_locked(&config)?;
+    Ok(result)
+}
+
+fn update_library_entry<R, F>(library_id: &str, mutator: F) -> Result<R, String>
+where
+    F: FnOnce(&mut Library) -> Result<R, String>,
+{
+    update_app_config(|config| {
+        let library = config
+            .libraries
+            .iter_mut()
+            .find(|library| library.id == library_id)
+            .ok_or_else(|| "Library not found".to_string())?;
+        mutator(library)
+    })
+}
+
+pub fn ensure_library_storage_write_allowed() -> Result<(), String> {
+    let move_state = storage_move_state()
+        .lock()
+        .map_err(|_| "Storage move state lock poisoned".to_string())?;
+
+    if move_state.library_id.is_some() && move_state.status == "running" {
+        return Err(LIBRARY_STORAGE_MOVE_IN_PROGRESS_ERROR.to_string());
+    }
+
+    Ok(())
+}
+
 fn save_app_config_locked(config: &AppConfig) -> Result<(), String> {
     let config_path = get_config_file_path()?;
     let content = serde_json::to_string_pretty(config)
@@ -373,6 +594,11 @@ fn parse_first_json_object<T: for<'de> Deserialize<'de>>(content: &str) -> Optio
 }
 
 fn write_atomic(path: &Path, content: &str) -> Result<(), String> {
+    #[cfg(test)]
+    if should_fail_config_write() {
+        return Err("Injected config write failure".to_string());
+    }
+
     let parent = path
         .parent()
         .ok_or_else(|| "Config path has no parent directory".to_string())?;
@@ -494,6 +720,8 @@ fn recover_app_config_from_library_dbs() -> Result<AppConfig, String> {
             created_at,
             state: LibraryState::default(),
             hidden: false,
+            storage_dir: None,
+            metadata_initialized: true,
         });
     }
 
@@ -516,17 +744,37 @@ fn recover_app_config_from_library_dbs() -> Result<AppConfig, String> {
     })
 }
 
-/// Get the database file path for a library
-pub fn get_library_db_path(library_id: &str) -> Result<String, String> {
-    let lib_dir = get_libraries_dir()?;
-    let db_path = lib_dir.join(format!("{}.db", library_id));
+/// Get the database file path for a library and ensure the storage directory is ready
+pub fn get_library_db_path_for_open(library_id: &str) -> Result<String, String> {
+    let config = load_app_config()?;
+    let library = find_library(&config, library_id)?;
+    let storage_dir = ensure_storage_dir_ready(library)?;
+    let db_path = storage_dir.join(format!("{}.db", library.id));
     Ok(db_path.to_string_lossy().into_owned())
 }
 
 /// Get the current library's database file path
 pub fn get_current_db_path() -> Result<String, String> {
     let config = load_app_config()?;
-    get_library_db_path(&config.current_library_id)
+    let library = find_library(&config, &config.current_library_id)?;
+    let db_path = library_db_path_from_library(library)?;
+    Ok(db_path.to_string_lossy().into_owned())
+}
+
+/// Get the current library's database file path and ensure the storage directory is ready
+pub fn get_current_db_path_for_open() -> Result<String, String> {
+    let config = load_app_config()?;
+    let library = find_library(&config, &config.current_library_id)?;
+    let storage_dir = ensure_storage_dir_ready(library)?;
+    let db_path = storage_dir.join(format!("{}.db", library.id));
+    Ok(db_path.to_string_lossy().into_owned())
+}
+
+pub fn mark_library_metadata_initialized(library_id: &str) -> Result<(), String> {
+    update_library_entry(library_id, |library| {
+        library.metadata_initialized = true;
+        Ok(())
+    })
 }
 
 /// Add a new library
@@ -549,6 +797,8 @@ pub fn add_library(name: &str) -> Result<Library, String> {
 
         state: LibraryState::default(),
         hidden: false,
+        storage_dir: None,
+        metadata_initialized: false,
     };
 
     config.libraries.push(library.clone());
@@ -583,11 +833,37 @@ pub fn edit_library(id: &str, new_name: &str) -> Result<(), String> {
 /// Remove a library (also deletes the database file)
 pub fn remove_library(id: &str) -> Result<(), String> {
     let mut config = load_app_config()?;
+    let original_config = config.clone();
 
     // Cannot remove the only remaining library
     if config.libraries.len() <= 1 {
         return Err("Cannot remove the last library".to_string());
     }
+
+    let library = config
+        .libraries
+        .iter()
+        .find(|l| l.id == id)
+        .cloned()
+        .ok_or_else(|| "Library not found".to_string())?;
+    let storage_available = is_storage_dir_available(&library)?;
+    if !storage_available && !library_allows_disconnected_metadata_operation(&library)? {
+        return Err(format!(
+            "Library storage is disconnected and still contains metadata. Reconnect the storage before deleting this library: {}",
+            library_db_path_from_library(&library)?.display()
+        ));
+    }
+    let db_path = library_db_path_from_library(&library)?;
+    let existing_paths = if storage_available {
+        existing_sqlite_files(&db_path)
+    } else {
+        Vec::new()
+    };
+    let quarantine_stamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_err(|e| format!("Failed to get timestamp for library deletion: {}", e))?
+        .as_nanos();
+    let quarantined_paths = move_paths_to_quarantine(&existing_paths, quarantine_stamp)?;
 
     // Find and remove the library
     let original_len = config.libraries.len();
@@ -602,12 +878,25 @@ pub fn remove_library(id: &str) -> Result<(), String> {
         config.current_library_id = config.libraries[0].id.clone();
     }
 
-    save_app_config(&config)?;
+    if let Err(save_error) = save_app_config(&config) {
+        let rollback_error = rollback_quarantined_paths(&quarantined_paths);
+        return Err(match rollback_error {
+            Ok(_) => save_error,
+            Err(file_error) => format!("{} Rollback failed: {}", save_error, file_error),
+        });
+    }
 
-    // Delete the database file
-    let db_path = get_library_db_path(id)?;
-    if std::path::Path::new(&db_path).exists() {
-        fs::remove_file(&db_path).map_err(|e| format!("Failed to delete database file: {}", e))?;
+    if let Err(cleanup_error) = cleanup_quarantined_paths(&quarantined_paths) {
+        let config_rollback_error = save_app_config(&original_config).err();
+        let file_rollback_error = rollback_quarantined_paths(&quarantined_paths).err();
+        let mut errors = vec![cleanup_error];
+        if let Some(error) = config_rollback_error {
+            errors.push(format!("Config rollback failed: {}", error));
+        }
+        if let Some(error) = file_rollback_error {
+            errors.push(format!("File rollback failed: {}", error));
+        }
+        return Err(errors.join(" | "));
     }
 
     Ok(())
@@ -636,49 +925,794 @@ pub struct LibraryInfo {
     pub db_file_path: String,
     pub file_count: i64,
     pub total_size: i64,
+    pub storage_dir: Option<String>,
+    pub uses_default_storage: bool,
+    pub storage_available: bool,
+    pub metadata_initialized: bool,
+}
+
+#[derive(Debug, Clone, Default)]
+struct LibraryStorageMoveState {
+    library_id: Option<String>,
+    phase: String,
+    status: String,
+    cancellable: bool,
+    cancel_requested: bool,
 }
 
 pub fn get_library_info(id: &str) -> Result<LibraryInfo, String> {
-    let db_path = get_library_db_path(id)?;
+    let config = load_app_config()?;
+    let library = find_library(&config, id)?;
+    let db_path = library_db_path_from_library(library)?;
+    let (storage_dir, uses_default_storage) = get_effective_storage_dir(library)?;
+    let storage_available = is_storage_dir_available(library)?;
+    let metadata_initialized = library_effective_metadata_initialized(library)?;
+    let db_path_ref = Path::new(&db_path);
+
+    if storage_available && db_path_ref.exists() && !library.metadata_initialized {
+        let _ = mark_library_metadata_initialized(id);
+    }
 
     // Get db file size
-    let db_file_size = if std::path::Path::new(&db_path).exists() {
+    let db_file_size = if db_path_ref.exists() {
         fs::metadata(&db_path).map(|m| m.len() as i64).unwrap_or(0)
     } else {
         0
     };
 
-    // Open connection to the library's DB to get file stats
-    let conn = rusqlite::Connection::open(&db_path)
-        .map_err(|e| format!("Failed to open library DB: {}", e))?;
+    let (file_count, total_size): (i64, i64) = if storage_available && db_path_ref.exists() {
+        let conn = rusqlite::Connection::open(&db_path)
+            .map_err(|e| format!("Failed to open library DB: {}", e))?;
 
-    let (file_count, total_size): (i64, i64) = conn
-        .query_row(
+        conn.query_row(
             "SELECT COUNT(id), COALESCE(SUM(size), 0) FROM afiles",
             [],
             |row| Ok((row.get(0)?, row.get(1)?)),
         )
-        .unwrap_or((0, 0));
+        .unwrap_or((0, 0))
+    } else {
+        (0, 0)
+    };
 
     Ok(LibraryInfo {
         db_file_size,
-        db_file_path: db_path,
+        db_file_path: db_path.to_string_lossy().into_owned(),
         file_count,
         total_size,
+        storage_dir: Some(storage_dir.to_string_lossy().into_owned()),
+        uses_default_storage,
+        storage_available,
+        metadata_initialized,
     })
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LibraryStorageMoveProgress {
+    pub library_id: String,
+    pub phase: String,
+    pub bytes_copied: u64,
+    pub total_bytes: u64,
+    pub percent: u64,
+    pub message: String,
+    pub cancellable: bool,
+    pub cancel_requested: bool,
+    pub status: String,
+}
+
+fn emit_library_storage_move_progress(
+    app_handle: &tauri::AppHandle,
+    library_id: &str,
+    phase: &str,
+    bytes_copied: u64,
+    total_bytes: u64,
+    cancellable: bool,
+    status: &str,
+    message: impl Into<String>,
+) {
+    let percent = if total_bytes == 0 {
+        if phase == "finished" { 100 } else { 0 }
+    } else {
+        ((bytes_copied.saturating_mul(100)) / total_bytes).min(100)
+    };
+
+    let move_state = {
+        let mut move_state = storage_move_state()
+            .lock()
+            .map_err(|_| "Storage move state lock poisoned".to_string())
+            .ok();
+
+        if let Some(ref mut move_state) = move_state {
+            move_state.library_id = Some(library_id.to_string());
+            move_state.phase = phase.to_string();
+            move_state.status = status.to_string();
+            move_state.cancellable = cancellable;
+            move_state.clone()
+        } else {
+            LibraryStorageMoveState {
+                library_id: Some(library_id.to_string()),
+                phase: phase.to_string(),
+                status: status.to_string(),
+                cancellable,
+                cancel_requested: false,
+            }
+        }
+    };
+
+    let _ = app_handle.emit(
+        "library-storage-move-progress",
+        LibraryStorageMoveProgress {
+            library_id: library_id.to_string(),
+            phase: phase.to_string(),
+            bytes_copied,
+            total_bytes,
+            percent,
+            message: message.into(),
+            cancellable: move_state.cancellable,
+            cancel_requested: move_state.cancel_requested,
+            status: move_state.status,
+        },
+    );
+}
+
+fn sqlite_related_paths(db_path: &Path) -> Vec<PathBuf> {
+    vec![
+        db_path.to_path_buf(),
+        PathBuf::from(format!("{}-wal", db_path.to_string_lossy())),
+        PathBuf::from(format!("{}-shm", db_path.to_string_lossy())),
+    ]
+}
+
+fn existing_sqlite_files(db_path: &Path) -> Vec<PathBuf> {
+    sqlite_related_paths(db_path)
+        .into_iter()
+        .filter(|path| path.exists())
+        .collect()
+}
+
+fn temp_storage_path(path: &Path, stamp: u128) -> PathBuf {
+    let file_name = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("library.db");
+    path.with_file_name(format!(
+        "{}.moving-{}-{}",
+        file_name,
+        std::process::id(),
+        stamp
+    ))
+}
+
+fn temp_delete_path(path: &Path, stamp: u128) -> PathBuf {
+    let file_name = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("library.db");
+    path.with_file_name(format!(
+        ".{}.delete-{}-{}",
+        file_name,
+        std::process::id(),
+        stamp
+    ))
+}
+
+fn cleanup_paths(paths: &[PathBuf]) {
+    for path in paths {
+        let _ = fs::remove_file(path);
+    }
+}
+
+fn move_paths_to_quarantine(
+    paths: &[PathBuf],
+    stamp: u128,
+) -> Result<Vec<(PathBuf, PathBuf)>, String> {
+    let mut quarantined = Vec::new();
+
+    for original_path in paths {
+        let quarantine_path = temp_delete_path(original_path, stamp);
+        fs::rename(original_path, &quarantine_path).map_err(|error| {
+            let _ = rollback_quarantined_paths(&quarantined);
+            format!(
+                "Failed to quarantine '{}' before library deletion: {}",
+                original_path.display(),
+                error
+            )
+        })?;
+        quarantined.push((original_path.clone(), quarantine_path));
+    }
+
+    Ok(quarantined)
+}
+
+fn rollback_quarantined_paths(paths: &[(PathBuf, PathBuf)]) -> Result<(), String> {
+    let mut errors = Vec::new();
+
+    for (original_path, quarantine_path) in paths.iter().rev() {
+        if !quarantine_path.exists() {
+            continue;
+        }
+
+        if let Err(error) = fs::rename(quarantine_path, original_path) {
+            errors.push(format!(
+                "Failed to restore '{}' from '{}': {}",
+                original_path.display(),
+                quarantine_path.display(),
+                error
+            ));
+        }
+    }
+
+    if errors.is_empty() {
+        Ok(())
+    } else {
+        Err(errors.join(" | "))
+    }
+}
+
+fn quarantine_delete_priority(path: &Path) -> u8 {
+    let path_string = path.to_string_lossy();
+    if path_string.contains("-wal") {
+        0
+    } else if path_string.contains("-shm") {
+        1
+    } else {
+        2
+    }
+}
+
+fn cleanup_quarantined_paths(paths: &[(PathBuf, PathBuf)]) -> Result<(), String> {
+    let mut ordered_paths = paths.to_vec();
+    ordered_paths.sort_by_key(|(_, quarantine_path)| quarantine_delete_priority(quarantine_path));
+
+    for (_, quarantine_path) in ordered_paths {
+        if !quarantine_path.exists() {
+            continue;
+        }
+
+        fs::remove_file(&quarantine_path).map_err(|error| {
+            format!(
+                "Failed to delete quarantined library file '{}': {}",
+                quarantine_path.display(),
+                error
+            )
+        })?;
+    }
+
+    Ok(())
+}
+
+const LIBRARY_STORAGE_MOVE_CANCELLED_ERROR: &str = "Library storage move cancelled.";
+
+struct LibraryStorageMoveStateGuard;
+
+impl Drop for LibraryStorageMoveStateGuard {
+    fn drop(&mut self) {
+        if let Ok(mut move_state) = storage_move_state().lock() {
+            *move_state = LibraryStorageMoveState::default();
+        }
+    }
+}
+
+fn start_library_storage_move(library_id: &str) -> Result<LibraryStorageMoveStateGuard, String> {
+    let mut move_state = storage_move_state()
+        .lock()
+        .map_err(|_| "Storage move state lock poisoned".to_string())?;
+    *move_state = LibraryStorageMoveState {
+        library_id: Some(library_id.to_string()),
+        phase: String::new(),
+        status: "running".to_string(),
+        cancellable: false,
+        cancel_requested: false,
+    };
+    Ok(LibraryStorageMoveStateGuard)
+}
+
+fn is_library_storage_move_cancel_requested(library_id: &str) -> Result<bool, String> {
+    let move_state = storage_move_state()
+        .lock()
+        .map_err(|_| "Storage move state lock poisoned".to_string())?;
+    Ok(move_state.library_id.as_deref() == Some(library_id) && move_state.cancel_requested)
+}
+
+pub fn cancel_library_storage_move(library_id: &str) -> Result<(), String> {
+    let mut move_state = storage_move_state()
+        .lock()
+        .map_err(|_| "Storage move state lock poisoned".to_string())?;
+
+    if move_state.library_id.as_deref() != Some(library_id) {
+        return Err("No active storage move for this library".to_string());
+    }
+
+    if !move_state.cancellable {
+        return Err("Library storage move can no longer be cancelled".to_string());
+    }
+
+    move_state.cancel_requested = true;
+    Ok(())
+}
+
+fn ensure_library_storage_move_not_cancelled(
+    library_id: &str,
+    app_handle: &tauri::AppHandle,
+    phase: &str,
+    bytes_copied: u64,
+    total_bytes: u64,
+) -> Result<(), String> {
+    if is_library_storage_move_cancel_requested(library_id)? {
+        emit_library_storage_move_progress(
+            app_handle,
+            library_id,
+            "cancelled",
+            bytes_copied,
+            total_bytes,
+            false,
+            "cancelled",
+            format!("Library storage move cancelled during {}", phase),
+        );
+        return Err(LIBRARY_STORAGE_MOVE_CANCELLED_ERROR.to_string());
+    }
+
+    Ok(())
+}
+
+fn hash_file_blake3(path: &Path, library_id: &str) -> Result<String, String> {
+    let mut file = fs::File::open(path)
+        .map_err(|e| format!("Failed to open '{}' for hashing: {}", path.display(), e))?;
+    let mut hasher = blake3::Hasher::new();
+    let mut buffer = [0u8; 1024 * 1024];
+
+    loop {
+        let read = file
+            .read(&mut buffer)
+            .map_err(|e| format!("Failed to read '{}' for hashing: {}", path.display(), e))?;
+        if read == 0 {
+            break;
+        }
+        hasher.update(&buffer[..read]);
+        if is_library_storage_move_cancel_requested(library_id)? {
+            return Err(LIBRARY_STORAGE_MOVE_CANCELLED_ERROR.to_string());
+        }
+    }
+
+    Ok(hasher.finalize().to_hex().to_string())
+}
+
+fn copy_file_with_progress(
+    source: &Path,
+    target: &Path,
+    copied_so_far: &mut u64,
+    total_bytes: u64,
+    app_handle: &tauri::AppHandle,
+    library_id: &str,
+) -> Result<(), String> {
+    let mut reader = fs::File::open(source)
+        .map_err(|e| format!("Failed to open '{}' for copying: {}", source.display(), e))?;
+    let mut writer = fs::File::create(target)
+        .map_err(|e| format!("Failed to create '{}' for copying: {}", target.display(), e))?;
+    let mut buffer = [0u8; 1024 * 1024];
+
+    loop {
+        ensure_library_storage_move_not_cancelled(
+            library_id,
+            app_handle,
+            "copying",
+            *copied_so_far,
+            total_bytes,
+        )?;
+        let read = reader
+            .read(&mut buffer)
+            .map_err(|e| format!("Failed to read '{}' while copying: {}", source.display(), e))?;
+        if read == 0 {
+            break;
+        }
+
+        writer.write_all(&buffer[..read]).map_err(|e| {
+            format!(
+                "Failed to write '{}' while copying: {}",
+                target.display(),
+                e
+            )
+        })?;
+        *copied_so_far = copied_so_far.saturating_add(read as u64);
+        emit_library_storage_move_progress(
+            app_handle,
+            library_id,
+            "copying",
+            *copied_so_far,
+            total_bytes,
+            true,
+            "running",
+            format!("Copying {}", source.display()),
+        );
+        ensure_library_storage_move_not_cancelled(
+            library_id,
+            app_handle,
+            "copying",
+            *copied_so_far,
+            total_bytes,
+        )?;
+    }
+
+    writer
+        .sync_all()
+        .map_err(|e| format!("Failed to sync '{}' after copying: {}", target.display(), e))?;
+
+    Ok(())
+}
+
+fn checkpoint_sqlite_db(db_path: &Path) -> Result<(), String> {
+    if !db_path.exists() {
+        return Ok(());
+    }
+
+    let conn = rusqlite::Connection::open(db_path).map_err(|e| {
+        format!(
+            "Failed to open '{}' for checkpoint: {}",
+            db_path.display(),
+            e
+        )
+    })?;
+    conn.execute_batch("PRAGMA wal_checkpoint(TRUNCATE);")
+        .map_err(|e| format!("Failed to checkpoint '{}': {}", db_path.display(), e))?;
+    Ok(())
+}
+
+pub fn move_library_storage(
+    app_handle: &tauri::AppHandle,
+    id: &str,
+    storage_dir: Option<String>,
+) -> Result<LibraryInfo, String> {
+    let _guard = storage_move_lock()
+        .lock()
+        .map_err(|_| "Storage move lock poisoned".to_string())?;
+
+    let config = load_app_config()?;
+    let library = config
+        .libraries
+        .iter()
+        .find(|library| library.id == id)
+        .cloned()
+        .ok_or_else(|| "Library not found".to_string())?;
+    let next_storage_dir = canonicalize_custom_storage_dir(storage_dir)?;
+
+    let (current_storage_dir, _) = get_effective_storage_dir(&library)?;
+    let source_storage_available = is_storage_dir_available(&library)?;
+    let current_compare_dir = if source_storage_available {
+        fs::canonicalize(&current_storage_dir).unwrap_or(current_storage_dir.clone())
+    } else {
+        current_storage_dir.clone()
+    };
+    let (target_storage_dir, target_uses_default) = match next_storage_dir.clone() {
+        Some(dir) => (PathBuf::from(dir), false),
+        None => {
+            let default_dir = get_libraries_dir()?;
+            (fs::canonicalize(&default_dir).unwrap_or(default_dir), true)
+        }
+    };
+
+    if current_compare_dir == target_storage_dir {
+        return get_library_info(id);
+    }
+
+    let _move_state_guard = start_library_storage_move(id)?;
+
+    let source_db_path = library_db_path_from_library(&library)?;
+    let target_db_path = target_storage_dir.join(format!("{}.db", library.id));
+    let target_related_paths = sqlite_related_paths(&target_db_path);
+
+    if target_related_paths
+        .iter()
+        .any(|path| path.exists() && !path.eq(&source_db_path))
+    {
+        return Err(format!(
+            "Target storage already contains database files for this library: {}",
+            target_db_path.display()
+        ));
+    }
+
+    if !source_storage_available {
+        if library_allows_disconnected_metadata_operation(&library)? {
+            emit_library_storage_move_progress(
+                app_handle,
+                id,
+                "committing",
+                0,
+                0,
+                false,
+                "running",
+                if target_uses_default {
+                    "Updating library storage to default location".to_string()
+                } else {
+                    format!(
+                        "Updating library storage to {}",
+                        target_storage_dir.display()
+                    )
+                },
+            );
+
+            update_library_entry(id, |library| {
+                library.storage_dir = next_storage_dir.clone();
+                Ok(())
+            })?;
+
+            emit_library_storage_move_progress(
+                app_handle,
+                id,
+                "finished",
+                0,
+                0,
+                false,
+                "finished",
+                "Library storage location updated successfully".to_string(),
+            );
+            return get_library_info(id);
+        }
+
+        return Err(format!(
+            "Library storage directory is unavailable and already contains metadata. Reconnect the storage first: {}",
+            current_storage_dir.display()
+        ));
+    }
+
+    let source_files = existing_sqlite_files(&source_db_path);
+    if source_files.is_empty() {
+        emit_library_storage_move_progress(
+            app_handle,
+            id,
+            "committing",
+            0,
+            0,
+            false,
+            "running",
+            if target_uses_default {
+                "Updating library storage to default location".to_string()
+            } else {
+                format!(
+                    "Updating library storage to {}",
+                    target_storage_dir.display()
+                )
+            },
+        );
+
+        update_library_entry(id, |library| {
+            library.storage_dir = next_storage_dir.clone();
+            Ok(())
+        })?;
+
+        emit_library_storage_move_progress(
+            app_handle,
+            id,
+            "finished",
+            0,
+            0,
+            false,
+            "finished",
+            "Library storage location updated successfully".to_string(),
+        );
+        return get_library_info(id);
+    }
+
+    checkpoint_sqlite_db(&source_db_path)?;
+
+    let source_files = existing_sqlite_files(&source_db_path);
+    let total_bytes = source_files
+        .iter()
+        .filter_map(|path| fs::metadata(path).ok().map(|meta| meta.len()))
+        .sum::<u64>();
+    emit_library_storage_move_progress(
+        app_handle,
+        id,
+        "copying",
+        0,
+        total_bytes,
+        true,
+        "running",
+        if target_uses_default {
+            "Copying metadata to default storage".to_string()
+        } else {
+            format!("Copying metadata to {}", target_storage_dir.display())
+        },
+    );
+    let stamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_err(|e| format!("Failed to get timestamp for storage move: {}", e))?
+        .as_nanos();
+    let temp_targets = source_files
+        .iter()
+        .map(|source_path| {
+            let suffix = source_path
+                .file_name()
+                .and_then(|name| name.to_str())
+                .and_then(|name| name.strip_prefix(&format!("{}.db", library.id)))
+                .unwrap_or("");
+            temp_storage_path(
+                &target_storage_dir.join(format!("{}.db{}", library.id, suffix)),
+                stamp,
+            )
+        })
+        .collect::<Vec<_>>();
+
+    let mut copied = 0u64;
+    for (source_path, temp_target) in source_files.iter().zip(temp_targets.iter()) {
+        if let Err(error) = copy_file_with_progress(
+            source_path,
+            temp_target,
+            &mut copied,
+            total_bytes,
+            app_handle,
+            id,
+        ) {
+            cleanup_paths(&temp_targets);
+            return Err(error);
+        }
+    }
+
+    emit_library_storage_move_progress(
+        app_handle,
+        id,
+        "verifying",
+        total_bytes,
+        total_bytes,
+        true,
+        "running",
+        "Verifying copied data".to_string(),
+    );
+
+    if let Err(error) = ensure_library_storage_move_not_cancelled(
+        id,
+        app_handle,
+        "verifying",
+        total_bytes,
+        total_bytes,
+    ) {
+        cleanup_paths(&temp_targets);
+        return Err(error);
+    }
+
+    for (source_path, temp_target) in source_files.iter().zip(temp_targets.iter()) {
+        let source_hash = match hash_file_blake3(source_path, id) {
+            Ok(hash) => hash,
+            Err(error) => {
+                cleanup_paths(&temp_targets);
+                if error == LIBRARY_STORAGE_MOVE_CANCELLED_ERROR {
+                    emit_library_storage_move_progress(
+                        app_handle,
+                        id,
+                        "cancelled",
+                        total_bytes,
+                        total_bytes,
+                        false,
+                        "cancelled",
+                        "Library storage move cancelled during verification".to_string(),
+                    );
+                }
+                return Err(error);
+            }
+        };
+        let target_hash = match hash_file_blake3(temp_target, id) {
+            Ok(hash) => hash,
+            Err(error) => {
+                cleanup_paths(&temp_targets);
+                if error == LIBRARY_STORAGE_MOVE_CANCELLED_ERROR {
+                    emit_library_storage_move_progress(
+                        app_handle,
+                        id,
+                        "cancelled",
+                        total_bytes,
+                        total_bytes,
+                        false,
+                        "cancelled",
+                        "Library storage move cancelled during verification".to_string(),
+                    );
+                }
+                return Err(error);
+            }
+        };
+        if source_hash != target_hash {
+            cleanup_paths(&temp_targets);
+            return Err(format!(
+                "Integrity verification failed for '{}'",
+                source_path.display()
+            ));
+        }
+    }
+
+    if let Err(error) = ensure_library_storage_move_not_cancelled(
+        id,
+        app_handle,
+        "verifying",
+        total_bytes,
+        total_bytes,
+    ) {
+        cleanup_paths(&temp_targets);
+        return Err(error);
+    }
+
+    emit_library_storage_move_progress(
+        app_handle,
+        id,
+        "committing",
+        total_bytes,
+        total_bytes,
+        false,
+        "running",
+        "Finalizing storage move".to_string(),
+    );
+
+    let final_targets = source_files
+        .iter()
+        .map(|source_path| {
+            let suffix = source_path
+                .file_name()
+                .and_then(|name| name.to_str())
+                .and_then(|name| name.strip_prefix(&format!("{}.db", library.id)))
+                .unwrap_or("");
+            target_storage_dir.join(format!("{}.db{}", library.id, suffix))
+        })
+        .collect::<Vec<_>>();
+
+    for target in &final_targets {
+        if target.exists() {
+            cleanup_paths(&temp_targets);
+            return Err(format!(
+                "Target storage already contains '{}'",
+                target.display()
+            ));
+        }
+    }
+
+    for (temp_target, final_target) in temp_targets.iter().zip(final_targets.iter()) {
+        if let Err(e) = fs::rename(temp_target, final_target) {
+            cleanup_paths(&temp_targets);
+            cleanup_paths(&final_targets);
+            return Err(format!(
+                "Failed to finalize storage move '{}': {}",
+                final_target.display(),
+                e
+            ));
+        }
+    }
+
+    if let Err(error) = update_library_entry(id, |library| {
+        library.storage_dir = next_storage_dir.clone();
+        Ok(())
+    }) {
+        cleanup_paths(&final_targets);
+        return Err(error);
+    }
+
+    for source_path in &source_files {
+        if source_path.exists() {
+            if let Err(error) = fs::remove_file(source_path) {
+                eprintln!(
+                    "Warning: failed to remove original storage file '{}' after move: {}",
+                    source_path.display(),
+                    error
+                );
+            }
+        }
+    }
+
+    emit_library_storage_move_progress(
+        app_handle,
+        id,
+        "finished",
+        total_bytes,
+        total_bytes,
+        false,
+        "finished",
+        "Library metadata moved successfully".to_string(),
+    );
+
+    get_library_info(id)
 }
 
 /// Save library state
 pub fn save_library_state(id: &str, state: LibraryState) -> Result<(), String> {
-    let mut config = load_app_config()?;
-
-    if let Some(lib) = config.libraries.iter_mut().find(|l| l.id == id) {
-        lib.state = state;
-        save_app_config(&config)?;
+    update_library_entry(id, |library| {
+        library.state = state;
         Ok(())
-    } else {
-        Err("Library not found".to_string())
-    }
+    })
 }
 
 /// Get library state
@@ -745,4 +1779,258 @@ pub fn reorder_libraries(ids: Vec<String>) -> Result<(), String> {
     save_app_config(&config)?;
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    static TEST_MUTEX: OnceLock<Mutex<()>> = OnceLock::new();
+
+    fn test_lock() -> &'static Mutex<()> {
+        TEST_MUTEX.get_or_init(|| Mutex::new(()))
+    }
+
+    struct TestEnv {
+        _guard: std::sync::MutexGuard<'static, ()>,
+        root: PathBuf,
+    }
+
+    impl TestEnv {
+        fn new() -> Self {
+            let guard = test_lock().lock().unwrap();
+            let stamp = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos();
+            let root = std::env::temp_dir().join(format!(
+                "lap-t-config-tests-{}-{}",
+                std::process::id(),
+                stamp
+            ));
+            fs::create_dir_all(&root).unwrap();
+            *app_data_dir_override().lock().unwrap() = Some(root.clone());
+            Self {
+                _guard: guard,
+                root,
+            }
+        }
+    }
+
+    impl Drop for TestEnv {
+        fn drop(&mut self) {
+            set_test_config_write_failure(false);
+            *app_data_dir_override().lock().unwrap() = None;
+            let _ = fs::remove_dir_all(&self.root);
+        }
+    }
+
+    fn library_fixture(
+        id: &str,
+        storage_dir: Option<String>,
+        metadata_initialized: bool,
+    ) -> Library {
+        Library {
+            id: id.to_string(),
+            name: format!("Library {}", id),
+            created_at: 0,
+            state: LibraryState::default(),
+            hidden: false,
+            storage_dir,
+            metadata_initialized,
+        }
+    }
+
+    #[test]
+    fn legacy_library_config_deserializes_without_storage_fields() {
+        let json = r#"{
+          "debug": false,
+          "current_library_id": "default",
+          "libraries": [{
+            "id": "default",
+            "name": "Default Library",
+            "created_at": 123,
+            "hidden": false
+          }]
+        }"#;
+
+        let config: AppConfig = serde_json::from_str(json).unwrap();
+        let library = &config.libraries[0];
+        assert_eq!(library.storage_dir, None);
+        assert!(!library.metadata_initialized);
+    }
+
+    #[test]
+    fn canonicalize_custom_storage_dir_requires_absolute_existing_directory() {
+        let env = TestEnv::new();
+        let custom_dir = env.root.join("external");
+        fs::create_dir_all(&custom_dir).unwrap();
+
+        let canonical =
+            canonicalize_custom_storage_dir(Some(custom_dir.to_string_lossy().into_owned()))
+                .unwrap()
+                .unwrap();
+        assert_eq!(
+            PathBuf::from(canonical),
+            fs::canonicalize(&custom_dir).unwrap()
+        );
+
+        let relative_error =
+            canonicalize_custom_storage_dir(Some("relative/path".to_string())).unwrap_err();
+        assert!(relative_error.contains("absolute path"));
+    }
+
+    #[test]
+    fn remove_library_rejects_disconnected_initialized_storage() {
+        let _env = TestEnv::new();
+        let unavailable_dir = std::env::temp_dir().join("lap-unavailable-storage");
+
+        let config = AppConfig {
+            debug: false,
+            current_library_id: "default".to_string(),
+            libraries: vec![
+                library_fixture("default", None, false),
+                library_fixture(
+                    "external",
+                    Some(unavailable_dir.to_string_lossy().into_owned()),
+                    true,
+                ),
+            ],
+        };
+        save_app_config(&config).unwrap();
+
+        let error = remove_library("external").unwrap_err();
+        assert!(error.contains("Reconnect the storage before deleting"));
+
+        let reloaded = load_app_config().unwrap();
+        assert!(
+            reloaded
+                .libraries
+                .iter()
+                .any(|library| library.id == "external")
+        );
+    }
+
+    #[test]
+    fn remove_library_allows_disconnected_uninitialized_storage() {
+        let _env = TestEnv::new();
+        let unavailable_dir = std::env::temp_dir().join("lap-unavailable-storage-empty");
+
+        let config = AppConfig {
+            debug: false,
+            current_library_id: "default".to_string(),
+            libraries: vec![
+                library_fixture("default", None, false),
+                library_fixture(
+                    "external",
+                    Some(unavailable_dir.to_string_lossy().into_owned()),
+                    false,
+                ),
+            ],
+        };
+        save_app_config(&config).unwrap();
+
+        remove_library("external").unwrap();
+
+        let reloaded = load_app_config().unwrap();
+        assert!(
+            !reloaded
+                .libraries
+                .iter()
+                .any(|library| library.id == "external")
+        );
+    }
+
+    #[test]
+    fn disconnected_metadata_policy_is_shared() {
+        let unavailable_dir = std::env::temp_dir().join("lap-disconnected-policy");
+        let empty_library = library_fixture(
+            "empty",
+            Some(unavailable_dir.to_string_lossy().into_owned()),
+            false,
+        );
+        let initialized_library = library_fixture(
+            "initialized",
+            Some(unavailable_dir.to_string_lossy().into_owned()),
+            true,
+        );
+
+        assert!(library_allows_disconnected_metadata_operation(&empty_library).unwrap());
+        assert!(!library_allows_disconnected_metadata_operation(&initialized_library).unwrap());
+    }
+
+    #[test]
+    fn library_storage_write_gate_blocks_while_move_is_active() {
+        let _env = TestEnv::new();
+        let _move_guard = start_library_storage_move("default").unwrap();
+
+        let error = ensure_library_storage_write_allowed().unwrap_err();
+        assert_eq!(error, LIBRARY_STORAGE_MOVE_IN_PROGRESS_ERROR);
+    }
+
+    #[test]
+    fn remove_library_rolls_back_quarantined_files_when_config_save_fails() {
+        let _env = TestEnv::new();
+        let config = AppConfig {
+            debug: false,
+            current_library_id: "default".to_string(),
+            libraries: vec![
+                library_fixture("default", None, false),
+                library_fixture("external", None, true),
+            ],
+        };
+        save_app_config(&config).unwrap();
+
+        let libraries_dir = get_libraries_dir().unwrap();
+        fs::create_dir_all(&libraries_dir).unwrap();
+        let db_path = libraries_dir.join("external.db");
+        let wal_path = PathBuf::from(format!("{}-wal", db_path.to_string_lossy()));
+        let shm_path = PathBuf::from(format!("{}-shm", db_path.to_string_lossy()));
+        fs::write(&db_path, b"db").unwrap();
+        fs::write(&wal_path, b"wal").unwrap();
+        fs::write(&shm_path, b"shm").unwrap();
+
+        set_test_config_write_failure(true);
+        let error = remove_library("external").unwrap_err();
+        set_test_config_write_failure(false);
+
+        assert!(error.contains("Injected config write failure"));
+        let reloaded = load_app_config().unwrap();
+        assert!(
+            reloaded
+                .libraries
+                .iter()
+                .any(|library| library.id == "external")
+        );
+        assert!(db_path.exists());
+        assert!(wal_path.exists());
+        assert!(shm_path.exists());
+    }
+
+    #[test]
+    fn create_db_fails_if_metadata_initialized_cannot_be_persisted() {
+        let _env = TestEnv::new();
+        let config = AppConfig {
+            debug: false,
+            current_library_id: "default".to_string(),
+            libraries: vec![library_fixture("default", None, false)],
+        };
+        save_app_config(&config).unwrap();
+
+        set_test_config_write_failure(true);
+        let error = crate::t_sqlite::create_db().unwrap_err();
+        set_test_config_write_failure(false);
+
+        assert!(error.contains("Injected config write failure"));
+        let db_path = get_current_db_path().unwrap();
+        assert!(Path::new(&db_path).exists());
+
+        let reloaded = load_app_config().unwrap();
+        let library = reloaded
+            .libraries
+            .iter()
+            .find(|library| library.id == "default")
+            .unwrap();
+        assert!(!library.metadata_initialized);
+    }
 }

--- a/src-tauri/src/t_sqlite.rs
+++ b/src-tauri/src/t_sqlite.rs
@@ -3245,11 +3245,15 @@ impl ALocation {
 
 /// get connection to the db
 fn open_conn() -> Result<Connection, String> {
-    let path = t_config::get_current_db_path()
+    let path = t_config::get_current_db_path_for_open()
         .map_err(|e| format!("Failed to get the database file path: {}", e))?;
 
-    let conn = Connection::open(&path)
-        .map_err(|e| format!("Failed to open database connection: {}", e))?;
+    open_conn_at_path(&path)
+}
+
+fn open_conn_at_path(path: &str) -> Result<Connection, String> {
+    let conn =
+        Connection::open(path).map_err(|e| format!("Failed to open database connection: {}", e))?;
 
     conn.busy_timeout(Duration::from_secs(5))
         .map_err(|e| format!("Failed to set SQLite busy timeout: {}", e))?;
@@ -3271,18 +3275,50 @@ fn open_conn() -> Result<Connection, String> {
 
 /// create all tables if not exists
 pub fn create_db() -> Result<(), String> {
-    match create_db_internal() {
+    let library_id = t_config::load_app_config()
+        .map_err(|e| format!("Failed to load app config: {}", e))?
+        .current_library_id;
+    let path = t_config::get_current_db_path_for_open()
+        .map_err(|e| format!("Failed to get the database file path: {}", e))?;
+    let result = match create_db_internal_at_path(&path) {
         Ok(_) => Ok(()),
         Err(err) => {
             eprintln!("create_db failed: {}. Trying recovery...", err);
-            recover_current_db_file()?;
-            create_db_internal().map_err(|e| format!("Database recovery retry failed: {}", e))
+            recover_db_file_at_path(Path::new(&path))?;
+            create_db_internal_at_path(&path)
+                .map_err(|e| format!("Database recovery retry failed: {}", e))
         }
+    };
+
+    if result.is_ok() {
+        t_config::mark_library_metadata_initialized(&library_id)?;
     }
+
+    result
 }
 
-fn create_db_internal() -> Result<(), String> {
-    let conn = open_conn()?;
+pub fn create_db_for_library(library_id: &str) -> Result<(), String> {
+    let path = t_config::get_library_db_path_for_open(library_id)
+        .map_err(|e| format!("Failed to get library database path: {}", e))?;
+    let result = match create_db_internal_at_path(&path) {
+        Ok(_) => Ok(()),
+        Err(err) => {
+            eprintln!("create_db_for_library failed: {}. Trying recovery...", err);
+            recover_db_file_at_path(Path::new(&path))?;
+            create_db_internal_at_path(&path)
+                .map_err(|e| format!("Database recovery retry failed: {}", e))
+        }
+    };
+
+    if result.is_ok() {
+        t_config::mark_library_metadata_initialized(library_id)?;
+    }
+
+    result
+}
+
+fn create_db_internal_at_path(path: &str) -> Result<(), String> {
+    let conn = open_conn_at_path(path)?;
 
     // albums table
     conn.execute(
@@ -3674,11 +3710,8 @@ fn create_db_internal() -> Result<(), String> {
     Ok(())
 }
 
-fn recover_current_db_file() -> Result<(), String> {
-    let db_path = t_config::get_current_db_path()
-        .map_err(|e| format!("Failed to get current db path during recovery: {}", e))?;
-    let db_path = PathBuf::from(db_path);
-
+fn recover_db_file_at_path(db_path: &Path) -> Result<(), String> {
+    let db_path = db_path.to_path_buf();
     if !db_path.exists() {
         // Nothing to quarantine, next create_db_internal will create a new DB.
         return Ok(());

--- a/src-tauri/src/t_utils.rs
+++ b/src-tauri/src/t_utils.rs
@@ -13,6 +13,8 @@ use reverse_geocoder::ReverseGeocoder;
 use std::collections::HashMap;
 use std::fs;
 use std::io::Read;
+#[cfg(target_os = "windows")]
+use std::os::windows::process::CommandExt;
 use std::panic::{self, AssertUnwindSafe};
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -20,8 +22,6 @@ use std::sync::{Arc, Mutex};
 use std::time::{SystemTime, UNIX_EPOCH};
 use tauri::{Emitter, Manager, State};
 use walkdir::WalkDir; // https://docs.rs/walkdir/2.5.0/walkdir/
-#[cfg(target_os = "windows")]
-use std::os::windows::process::CommandExt;
 
 #[cfg(target_os = "windows")]
 const CREATE_NO_WINDOW: u32 = 0x0800_0000;

--- a/src-tauri/src/t_video.rs
+++ b/src-tauri/src/t_video.rs
@@ -28,14 +28,8 @@ fn ffmpeg_catch_panic<T>(
     match panic::catch_unwind(AssertUnwindSafe(op)) {
         Ok(inner) => inner,
         Err(_) => {
-            eprintln!(
-                "Panic caught during {} for video file: {}",
-                context, path
-            );
-            Err(format!(
-                "{}{}: {}",
-                FFMPEG_PANIC_ERR_PREFIX, context, path
-            ))
+            eprintln!("Panic caught during {} for video file: {}", context, path);
+            Err(format!("{}{}: {}", FFMPEG_PANIC_ERR_PREFIX, context, path))
         }
     }
 }
@@ -97,7 +91,10 @@ pub fn get_video_dimensions(file_path: &str) -> Result<(u32, u32), String> {
     }) {
         Ok(dims) => Ok(dims),
         Err(e) if is_ffmpeg_panic_err(&e) => {
-            eprintln!("Degrading video dimensions to 0×0 after FFmpeg panic: {}", e);
+            eprintln!(
+                "Degrading video dimensions to 0×0 after FFmpeg panic: {}",
+                e
+            );
             Ok((0, 0))
         }
         Err(e) => Err(e),
@@ -132,7 +129,9 @@ fn get_video_dimensions_inner(file_path: &str) -> Result<(u32, u32), String> {
 
 /// get video duration using ffmpeg
 pub fn get_video_duration(file_path: &str) -> Result<u64, String> {
-    match ffmpeg_catch_panic(file_path, "reading duration", || get_video_duration_inner(file_path)) {
+    match ffmpeg_catch_panic(file_path, "reading duration", || {
+        get_video_duration_inner(file_path)
+    }) {
         Ok(d) => Ok(d),
         Err(e) if is_ffmpeg_panic_err(&e) => {
             eprintln!("Degrading video duration to 0 after FFmpeg panic: {}", e);
@@ -324,10 +323,15 @@ pub struct VideoMetadata {
 }
 
 pub fn get_video_metadata(file_path: &str) -> Result<VideoMetadata, String> {
-    match ffmpeg_catch_panic(file_path, "reading metadata", || get_video_metadata_inner(file_path)) {
+    match ffmpeg_catch_panic(file_path, "reading metadata", || {
+        get_video_metadata_inner(file_path)
+    }) {
         Ok(m) => Ok(m),
         Err(e) if is_ffmpeg_panic_err(&e) => {
-            eprintln!("Degrading video metadata to empty after FFmpeg panic: {}", e);
+            eprintln!(
+                "Degrading video metadata to empty after FFmpeg panic: {}",
+                e
+            );
             Ok(VideoMetadata::default())
         }
         Err(e) => Err(e),
@@ -441,7 +445,6 @@ fn get_video_metadata_inner(file_path: &str) -> Result<VideoMetadata, String> {
 
     Ok(m)
 }
-
 
 /// Pick the first valid entry from a list of possible tag keys
 fn first_exist(meta: &HashMap<String, String>, keys: &[&str]) -> Option<String> {

--- a/src-vite/package.json
+++ b/src-vite/package.json
@@ -7,6 +7,7 @@
     "dev": "vite --config vite.config.js",
     "dev:clean": "vite --config vite.config.js --force",
     "build": "vite build",
+    "test": "vitest run",
     "preview": "vite preview"
   },
   "dependencies": {
@@ -38,14 +39,17 @@
     "@types/node": "^25.5.0",
     "@vitejs/plugin-vue": "^6.0.5",
     "@vue/compiler-sfc": "^3.5.31",
+    "@vue/test-utils": "^2.4.6",
     "autoprefixer": "^10.4.27",
     "daisyui": "5.5.19",
+    "jsdom": "^29.0.1",
     "postcss": "^8.5.8",
     "tailwindcss": "^4.2.2",
     "typescript": "^6.0.2",
     "vite": "^8.0.3",
     "vite-plugin-vue-devtools": "^8.1.1",
-    "vite-svg-loader": "^5.1.1"
+    "vite-svg-loader": "^5.1.1",
+    "vitest": "^4.1.2"
   },
   "license": "GPL-3.0-or-later"
 }

--- a/src-vite/pnpm-lock.yaml
+++ b/src-vite/pnpm-lock.yaml
@@ -87,12 +87,18 @@ importers:
       '@vue/compiler-sfc':
         specifier: ^3.5.31
         version: 3.5.31
+      '@vue/test-utils':
+        specifier: ^2.4.6
+        version: 2.4.6
       autoprefixer:
         specifier: ^10.4.27
         version: 10.4.27(postcss@8.5.8)
       daisyui:
         specifier: 5.5.19
         version: 5.5.19
+      jsdom:
+        specifier: ^29.0.1
+        version: 29.0.1
       postcss:
         specifier: ^8.5.8
         version: 8.5.8
@@ -111,6 +117,9 @@ importers:
       vite-svg-loader:
         specifier: ^5.1.1
         version: 5.1.1(vue@3.5.31(typescript@6.0.2))
+      vitest:
+        specifier: ^4.1.2
+        version: 4.1.2(@types/node@25.5.0)(jsdom@29.0.1)(vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.5.0)(jiti@2.6.1)(yaml@2.8.3))
 
 packages:
 
@@ -120,6 +129,17 @@ packages:
 
   '@aptabase/tauri@0.4.1':
     resolution: {integrity: sha512-ZjCtPN1Tw0y90nxMLR64UqFjgikxfc9NZouxqXlqZFkfpF8D/tPf1xUn0Anu8nvERGND/hAkO3x7ZLyLGI1HRg==}
+
+  '@asamuzakjp/css-color@5.1.1':
+    resolution: {integrity: sha512-iGWN8E45Ws0XWx3D44Q1t6vX2LqhCKcwfmwBYCDsFrYFS6m4q/Ks61L2veETaLv+ckDC6+dTETJoaAAb7VjLiw==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/dom-selector@7.0.4':
+    resolution: {integrity: sha512-jXR6x4AcT3eIrS2fSNAwJpwirOkGcd+E7F7CP3zjdTqz9B/2huHOL8YJZBgekKwLML+u7qB/6P1LXQuMScsx0w==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/nwsapi@2.3.9':
+    resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
 
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
@@ -265,6 +285,46 @@ packages:
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
 
+  '@bramus/specificity@2.4.2':
+    resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
+    hasBin: true
+
+  '@csstools/color-helpers@6.0.2':
+    resolution: {integrity: sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==}
+    engines: {node: '>=20.19.0'}
+
+  '@csstools/css-calc@3.1.1':
+    resolution: {integrity: sha512-HJ26Z/vmsZQqs/o3a6bgKslXGFAungXGbinULZO3eMsOyNJHeBBZfup5FiZInOghgoM4Hwnmw+OgbJCNg1wwUQ==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-color-parser@4.0.2':
+    resolution: {integrity: sha512-0GEfbBLmTFf0dJlpsNU7zwxRIH0/BGEMuXLTCvFYxuL1tNhqzTbtnFICyJLTNK4a+RechKP75e7w42ClXSnJQw==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0':
+    resolution: {integrity: sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.2':
+    resolution: {integrity: sha512-5GkLzz4prTIpoyeUiIu3iV6CSG3Plo7xRVOFPKI7FVEJ3mZ0A8SwK0XU3Gl7xAkiQ+mDyam+NNp875/C5y+jSA==}
+    peerDependencies:
+      css-tree: ^3.2.1
+    peerDependenciesMeta:
+      css-tree:
+        optional: true
+
+  '@csstools/css-tokenizer@4.0.0':
+    resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
+    engines: {node: '>=20.19.0'}
+
   '@emnapi/core@1.9.1':
     resolution: {integrity: sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA==}
 
@@ -273,6 +333,15 @@ packages:
 
   '@emnapi/wasi-threads@1.2.0':
     resolution: {integrity: sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==}
+
+  '@exodus/bytes@1.15.0':
+    resolution: {integrity: sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+    peerDependencies:
+      '@noble/hashes': ^1.8.0 || ^2.0.0
+    peerDependenciesMeta:
+      '@noble/hashes':
+        optional: true
 
   '@intlify/core-base@11.3.0':
     resolution: {integrity: sha512-NNX5jIwF4TJBe7RtSKDMOA6JD9mp2mRcBHAwt2X+Q8PvnZub0yj5YYXlFu2AcESdgQpEv/5Yx2uOCV/yh7YkZg==}
@@ -289,6 +358,10 @@ packages:
   '@intlify/shared@11.3.0':
     resolution: {integrity: sha512-LC6P/uay7rXL5zZ5+5iRJfLs/iUN8apu9tm8YqQVmW3Uq3X4A0dOFUIDuAmB7gAC29wTHOS3EiN/IosNSz0eNQ==}
     engines: {node: '>= 16'}
+
+  '@isaacs/cliui@8.0.2':
+    resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
+    engines: {node: '>=12'}
 
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
@@ -316,8 +389,15 @@ packages:
     resolution: {integrity: sha512-l+hY8sy2XFfg3PigZj+PTu6+KIJzmbACTRimn1ew/gtCz+F38f6KTF4sMRTN5CUxiB8TRENgEonASmkAWfpO9Q==}
     engines: {node: '>=18.12.0'}
 
+  '@one-ini/wasm@0.1.1':
+    resolution: {integrity: sha512-XuySG1E38YScSJoMlqovLru4KTUNSjgVTIjyh7qMX6aNN5HY5Ct5LhRJdxO79JtTzKfzV/bnWpz+zquYrISsvw==}
+
   '@oxc-project/types@0.122.0':
     resolution: {integrity: sha512-oLAl5kBpV4w69UtFZ9xqcmTi+GENWOcPF7FCrczTiBbmC0ibXxCwyvZGbO39rCVEuLGAZM84DH0pUIyyv/YJzA==}
+
+  '@pkgjs/parseargs@0.11.0':
+    resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
+    engines: {node: '>=14'}
 
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
@@ -357,42 +437,36 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.12':
     resolution: {integrity: sha512-V6/wZztnBqlx5hJQqNWwFdxIKN0m38p8Jas+VoSfgH54HSj9tKTt1dZvG6JRHcjh6D7TvrJPWFGaY9UBVOaWPw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.12':
     resolution: {integrity: sha512-AP3E9BpcUYliZCxa3w5Kwj9OtEVDYK6sVoUzy4vTOJsjPOgdaJZKFmN4oOlX0Wp0RPV2ETfmIra9x1xuayFB7g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.12':
     resolution: {integrity: sha512-nWwpvUSPkoFmZo0kQazZYOrT7J5DGOJ/+QHHzjvNlooDZED8oH82Yg67HvehPPLAg5fUff7TfWFHQS8IV1n3og==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.12':
     resolution: {integrity: sha512-RNrafz5bcwRy+O9e6P8Z/OCAJW/A+qtBczIqVYwTs14pf4iV1/+eKEjdOUta93q2TsT/FI0XYDP3TCky38LMAg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.0-rc.12':
     resolution: {integrity: sha512-Jpw/0iwoKWx3LJ2rc1yjFrj+T7iHZn2JDg1Yny1ma0luviFS4mhAIcd1LFNxK3EYu3DHWCps0ydXQ5i/rrJ2ig==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.0-rc.12':
     resolution: {integrity: sha512-vRugONE4yMfVn0+7lUKdKvN4D5YusEiPilaoO2sgUWpCvrncvWgPMzK00ZFFJuiPgLwgFNP5eSiUlv2tfc+lpA==}
@@ -422,6 +496,9 @@ packages:
 
   '@rolldown/pluginutils@1.0.0-rc.2':
     resolution: {integrity: sha512-izyXV/v+cHiRfozX62W9htOAvwMo4/bXKDrQ+vom1L1qRuexPock/7VZDAhnpHCLNejd3NJ6hiab+tO0D44Rgw==}
+
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
   '@tailwindcss/node@4.2.2':
     resolution: {integrity: sha512-pXS+wJ2gZpVXqFaUEjojq7jzMpTGf8rU6ipJz5ovJV6PUGmlJ+jvIwGrzdHdQ80Sg+wmQxUFuoW1UAAwHNEdFA==}
@@ -461,28 +538,24 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.2.2':
     resolution: {integrity: sha512-oCfG/mS+/+XRlwNjnsNLVwnMWYH7tn/kYPsNPh+JSOMlnt93mYNCKHYzylRhI51X+TbR+ufNhhKKzm6QkqX8ag==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.2.2':
     resolution: {integrity: sha512-rTAGAkDgqbXHNp/xW0iugLVmX62wOp2PoE39BTCGKjv3Iocf6AFbRP/wZT/kuCxC9QBh9Pu8XPkv/zCZB2mcMg==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.2.2':
     resolution: {integrity: sha512-XW3t3qwbIwiSyRCggeO2zxe3KWaEbM0/kW9e8+0XpBgyKU4ATYzcVSMKteZJ1iukJ3HgHBjbg9P5YPRCVUxlnQ==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.2.2':
     resolution: {integrity: sha512-eKSztKsmEsn1O5lJ4ZAfyn41NfG7vzCg496YiGtMDV86jz1q/irhms5O0VrY6ZwTUkFy/EKG3RfWgxSI3VbZ8Q==}
@@ -551,6 +624,12 @@ packages:
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
 
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
@@ -579,6 +658,35 @@ packages:
     peerDependencies:
       vite: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
       vue: ^3.2.25
+
+  '@vitest/expect@4.1.2':
+    resolution: {integrity: sha512-gbu+7B0YgUJ2nkdsRJrFFW6X7NTP44WlhiclHniUhxADQJH5Szt9mZ9hWnJPJ8YwOK5zUOSSlSvyzRf0u1DSBQ==}
+
+  '@vitest/mocker@4.1.2':
+    resolution: {integrity: sha512-Ize4iQtEALHDttPRCmN+FKqOl2vxTiNUhzobQFFt/BM1lRUTG7zRCLOykG/6Vo4E4hnUdfVLo5/eqKPukcWW7Q==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.2':
+    resolution: {integrity: sha512-dwQga8aejqeuB+TvXCMzSQemvV9hNEtDDpgUKDzOmNQayl2OG241PSWeJwKRH3CiC+sESrmoFd49rfnq7T4RnA==}
+
+  '@vitest/runner@4.1.2':
+    resolution: {integrity: sha512-Gr+FQan34CdiYAwpGJmQG8PgkyFVmARK8/xSijia3eTFgVfpcpztWLuP6FttGNfPLJhaZVP/euvujeNYar36OQ==}
+
+  '@vitest/snapshot@4.1.2':
+    resolution: {integrity: sha512-g7yfUmxYS4mNxk31qbOYsSt2F4m1E02LFqO53Xpzg3zKMhLAPZAjjfyl9e6z7HrW6LvUdTwAQR3HHfLjpko16A==}
+
+  '@vitest/spy@4.1.2':
+    resolution: {integrity: sha512-DU4fBnbVCJGNBwVA6xSToNXrkZNSiw59H8tcuUspVMsBDBST4nfvsPsEHDHGtWRRnqBERBQu7TrTKskmjqTXKA==}
+
+  '@vitest/utils@4.1.2':
+    resolution: {integrity: sha512-xw2/TiX82lQHA06cgbqRKFb5lCAy3axQ4H4SoUFhUsg+wztiet+co86IAMDtF6Vm1hc7J6j09oh/rgDn+JdKIQ==}
 
   '@vue-macros/common@3.1.2':
     resolution: {integrity: sha512-h9t4ArDdniO9ekYHAD95t9AZcAbb19lEGK+26iAjUODOIJKmObDNBSe4+6ELQAA3vtYiFPPBtHh7+cQCKi3Dng==}
@@ -660,9 +768,16 @@ packages:
   '@vue/shared@3.5.31':
     resolution: {integrity: sha512-nBxuiuS9Lj5bPkPbWogPUnjxxWpkRniX7e5UBQDWl6Fsf4roq9wwV+cR7ezQ4zXswNvPIlsdj1slcLB7XCsRAw==}
 
+  '@vue/test-utils@2.4.6':
+    resolution: {integrity: sha512-FMxEjOpYNYiFe0GkaHsnJPXFHxQ6m4t8vI/ElPGpMWxZKpmRvQ33OIrvRXemy6yha03RxhOlQuy+gZMC3CQSow==}
+
   '@xmldom/xmldom@0.8.11':
     resolution: {integrity: sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==}
     engines: {node: '>=10.0.0'}
+
+  abbrev@2.0.0:
+    resolution: {integrity: sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
 
   acorn@8.16.0:
     resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
@@ -672,9 +787,29 @@ packages:
   aes-decrypter@4.0.2:
     resolution: {integrity: sha512-lc+/9s6iJvuaRe5qDlMTpCFjnwpkeOXp8qP3oiZ5jsj1MRg+SBVUmmICrhxHvc8OELSmc+fEyyxAuppY6hrWzw==}
 
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
+  ansi-regex@6.2.2:
+    resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
+    engines: {node: '>=12'}
+
+  ansi-styles@4.3.0:
+    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
+    engines: {node: '>=8'}
+
+  ansi-styles@6.2.3:
+    resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
+    engines: {node: '>=12'}
+
   ansis@4.2.0:
     resolution: {integrity: sha512-HqZ5rWlFjGiV0tDm3UxxgNRqsOTniqoKZu0pIAfh7TZQMGuZK+hH0drySty0si0QXj1ieop4+SkSfPZBPPkHig==}
     engines: {node: '>=14'}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
 
   ast-kit@2.2.0:
     resolution: {integrity: sha512-m1Q/RaVOnTp9JxPX+F+Zn7IcLYMzM8kZofDImfsKZd8MbR+ikdOzTeztStWqfrqIxZnYWryyI9ePm3NGjnZgGw==}
@@ -691,16 +826,25 @@ packages:
     peerDependencies:
       postcss: ^8.1.0
 
+  balanced-match@1.0.2:
+    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
   baseline-browser-mapping@2.10.12:
     resolution: {integrity: sha512-qyq26DxfY4awP2gIRXhhLWfwzwI+N5Nxk6iQi8EFizIaWIjqicQTE4sLnZZVdeKPRcVNoJOkkpfzoIYuvCKaIQ==}
     engines: {node: '>=6.0.0'}
     hasBin: true
+
+  bidi-js@1.0.3:
+    resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
 
   birpc@2.9.0:
     resolution: {integrity: sha512-KrayHS5pBi69Xi9JmvoqrIgYGDkD6mcSe/i6YKi3w5kekCLzrX4+nawcXqrj2tIp50Kw/mT/s3p+GVK0A0sKxw==}
 
   boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
+
+  brace-expansion@2.0.3:
+    resolution: {integrity: sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==}
 
   browserslist@4.28.1:
     resolution: {integrity: sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==}
@@ -722,6 +866,10 @@ packages:
   caniuse-lite@1.0.30001781:
     resolution: {integrity: sha512-RdwNCyMsNBftLjW6w01z8bKEvT6e/5tpPVEgtn22TiLGlstHOVecsX2KHFkD5e/vRnIE4EGzpuIODb3mtswtkw==}
 
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
+
   chokidar@5.0.0:
     resolution: {integrity: sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==}
     engines: {node: '>= 20.19.0'}
@@ -732,6 +880,17 @@ packages:
   citty@0.2.1:
     resolution: {integrity: sha512-kEV95lFBhQgtogAPlQfJJ0WGVSokvLr/UEoFPiKKOXF7pl98HfUVUD0ejsuTCld/9xH9vogSywZ5KqHzXrZpqg==}
 
+  color-convert@2.0.1:
+    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
+    engines: {node: '>=7.0.0'}
+
+  color-name@1.1.4:
+    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  commander@10.0.1:
+    resolution: {integrity: sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==}
+    engines: {node: '>=14'}
+
   commander@7.2.0:
     resolution: {integrity: sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==}
     engines: {node: '>= 10'}
@@ -741,6 +900,9 @@ packages:
 
   confbox@0.2.4:
     resolution: {integrity: sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==}
+
+  config-chain@1.1.13:
+    resolution: {integrity: sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==}
 
   consola@3.4.2:
     resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
@@ -753,6 +915,10 @@ packages:
     resolution: {integrity: sha512-7Vv6asjS4gMOuILabD3l739tsaxFQmC+a7pLZm02zyvs8p977bL3zEgq3yDk5rn9B0PbYgIv++jmHcuUab4RhA==}
     engines: {node: '>=18'}
 
+  cross-spawn@7.0.6:
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
+    engines: {node: '>= 8'}
+
   css-select@5.2.2:
     resolution: {integrity: sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==}
 
@@ -762,6 +928,10 @@ packages:
 
   css-tree@2.3.1:
     resolution: {integrity: sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
+
+  css-tree@3.2.1:
+    resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
     engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
 
   css-what@6.2.2:
@@ -778,6 +948,10 @@ packages:
   daisyui@5.5.19:
     resolution: {integrity: sha512-pbFAkl1VCEh/MPCeclKL61I/MqRIFFhNU7yiXoDDRapXN4/qNCoMxeCCswyxEEhqL5eiTTfwHvucFtOE71C9sA==}
 
+  data-urls@7.0.0:
+    resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
   date-fns@4.1.0:
     resolution: {integrity: sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==}
 
@@ -789,6 +963,9 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
   default-browser-id@5.0.1:
     resolution: {integrity: sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==}
@@ -832,8 +1009,22 @@ packages:
     resolution: {integrity: sha512-IO8C/dzEb6O3F9/twg6ZLXz164a2fhTnEWb95H23Dm4OuN+92NmEAlTrupP9VW6Jm3sO26tQlqyvyi4CsnY9GA==}
     engines: {node: '>=12'}
 
+  eastasianwidth@0.2.0:
+    resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
+
+  editorconfig@1.0.7:
+    resolution: {integrity: sha512-e0GOtq/aTQhVdNyDU9e02+wz9oDDM+SIOQxWME2QRjzRX5yyLAuHDE+0aE8vHb9XRC8XD37eO2u57+F09JqFhw==}
+    engines: {node: '>=14'}
+    hasBin: true
+
   electron-to-chromium@1.5.328:
     resolution: {integrity: sha512-QNQ5l45DzYytThO21403XN3FvK0hOkWDG8viNf6jqS42msJ8I4tGDSpBCgvDRRPnkffafiwAym2X2eHeGD2V0w==}
+
+  emoji-regex@8.0.0:
+    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
+  emoji-regex@9.2.2:
+    resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
 
   enhanced-resolve@5.20.1:
     resolution: {integrity: sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==}
@@ -841,6 +1032,10 @@ packages:
 
   entities@4.5.0:
     resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
+    engines: {node: '>=0.12'}
+
+  entities@6.0.1:
+    resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
     engines: {node: '>=0.12'}
 
   entities@7.0.1:
@@ -852,6 +1047,9 @@ packages:
 
   errx@0.1.0:
     resolution: {integrity: sha512-fZmsRiDNv07K6s2KkKFTiD2aIvECa7++PKyD5NC32tpRw46qZA3sOz+aM+/V9V0GDHxVTKLziveV4JhzBHDp9Q==}
+
+  es-module-lexer@2.0.0:
+    resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
 
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
@@ -867,6 +1065,10 @@ packages:
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
 
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
+
   exsolve@1.0.8:
     resolution: {integrity: sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==}
 
@@ -878,6 +1080,10 @@ packages:
     peerDependenciesMeta:
       picomatch:
         optional: true
+
+  foreground-child@3.3.1:
+    resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
+    engines: {node: '>=14'}
 
   fraction.js@5.3.4:
     resolution: {integrity: sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==}
@@ -895,6 +1101,11 @@ packages:
     resolution: {integrity: sha512-L5bGsVkxJbJgdnwyuheIunkGatUF/zssUoxxjACCseZYAVbaqdh9Tsmmlkl8vYan09H7sbvKt4pS8GqKLBrEzA==}
     hasBin: true
 
+  glob@10.5.0:
+    resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+    hasBin: true
+
   global@4.4.0:
     resolution: {integrity: sha512-wv/LAoHdRE3BeTGz53FAamhGlPLhlssK45usmGFThIi4XqnBmjKQ16u+RNbP7WvigRZDxUsM0J3gcQ5yicaL0w==}
 
@@ -904,14 +1115,25 @@ packages:
   hookable@5.5.3:
     resolution: {integrity: sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==}
 
+  html-encoding-sniffer@6.0.0:
+    resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
   ignore@7.0.5:
     resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
     engines: {node: '>= 4'}
+
+  ini@1.3.8:
+    resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
 
   is-docker@3.0.0:
     resolution: {integrity: sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     hasBin: true
+
+  is-fullwidth-code-point@3.0.0:
+    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
+    engines: {node: '>=8'}
 
   is-function@1.0.2:
     resolution: {integrity: sha512-lw7DUp0aWXYg+CBCN+JKkcE0Q2RayZnSvnZBlwgxHBQhqt5pZNVy4Ri7H9GmmXkdu7LUthszM+Tor1u/2iBcpQ==}
@@ -921,6 +1143,9 @@ packages:
     engines: {node: '>=14.16'}
     hasBin: true
 
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
   is-what@5.5.0:
     resolution: {integrity: sha512-oG7cgbmg5kLYae2N5IVd3jm2s+vldjxJzK1pcu9LfpGuQ93MQSzo0okvRna+7y5ifrD+20FE8FvjusyGaz14fw==}
     engines: {node: '>=18'}
@@ -929,15 +1154,39 @@ packages:
     resolution: {integrity: sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==}
     engines: {node: '>=16'}
 
+  isexe@2.0.0:
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  jackspeak@3.4.3:
+    resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
+
   jiti@2.6.1:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
+
+  js-beautify@1.15.4:
+    resolution: {integrity: sha512-9/KXeZUKKJwqCXUdBxFJ3vPh467OCckSBmYDwSK/EtV090K+iMJ7zx2S3HLVDIWFQdqMIsZWbnaGiba18aWhaA==}
+    engines: {node: '>=14'}
+    hasBin: true
+
+  js-cookie@3.0.5:
+    resolution: {integrity: sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==}
+    engines: {node: '>=14'}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
   js-tokens@9.0.1:
     resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
+
+  jsdom@29.0.1:
+    resolution: {integrity: sha512-z6JOK5gRO7aMybVq/y/MlIpKh8JIi68FBKMUtKkK2KH/wMSRlCxQ682d08LB9fYXplyY/UXG8P4XXTScmdjApg==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24.0.0}
+    peerDependencies:
+      canvas: ^3.0.0
+    peerDependenciesMeta:
+      canvas:
+        optional: true
 
   jsesc@3.1.0:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
@@ -997,28 +1246,24 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -1043,6 +1288,13 @@ packages:
   lodash@4.17.23:
     resolution: {integrity: sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==}
 
+  lru-cache@10.4.3:
+    resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
+
+  lru-cache@11.2.7:
+    resolution: {integrity: sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==}
+    engines: {node: 20 || >=22}
+
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
@@ -1062,8 +1314,19 @@ packages:
   mdn-data@2.0.30:
     resolution: {integrity: sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==}
 
+  mdn-data@2.27.1:
+    resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
+
   min-document@2.19.2:
     resolution: {integrity: sha512-8S5I8db/uZN8r9HSLFVWPdJCvYOejMcEC82VIzNUc6Zkklf/d1gg2psfE79/vyhWOj4+J8MtwmoOz3TmvaGu5A==}
+
+  minimatch@9.0.9:
+    resolution: {integrity: sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
+  minipass@7.1.3:
+    resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
+    engines: {node: '>=16 || 14 >=14.17'}
 
   mitt@3.0.1:
     resolution: {integrity: sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==}
@@ -1101,6 +1364,11 @@ packages:
   node-releases@2.0.36:
     resolution: {integrity: sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==}
 
+  nopt@7.2.1:
+    resolution: {integrity: sha512-taM24ViiimT/XntxbPyJQzCG+p4EKOpgD3mxFwW38mGjVUrfERQOeY4EDHjdnptttfHuHQXFx+lTP08Q+mLa/w==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+    hasBin: true
+
   nth-check@2.1.1:
     resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
 
@@ -1109,12 +1377,29 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  obug@2.1.1:
+    resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+
   ohash@2.0.11:
     resolution: {integrity: sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==}
 
   open@10.2.0:
     resolution: {integrity: sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==}
     engines: {node: '>=18'}
+
+  package-json-from-dist@1.0.1:
+    resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
+
+  parse5@8.0.0:
+    resolution: {integrity: sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==}
+
+  path-key@3.1.1:
+    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
+    engines: {node: '>=8'}
+
+  path-scurry@1.11.1:
+    resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
+    engines: {node: '>=16 || 14 >=14.18'}
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
@@ -1181,6 +1466,13 @@ packages:
     resolution: {integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==}
     engines: {node: '>= 0.6.0'}
 
+  proto-list@1.2.4:
+    resolution: {integrity: sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==}
+
+  punycode@2.3.1:
+    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
+    engines: {node: '>=6'}
+
   quansync@0.2.11:
     resolution: {integrity: sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA==}
 
@@ -1190,6 +1482,10 @@ packages:
   readdirp@5.0.0:
     resolution: {integrity: sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==}
     engines: {node: '>= 20.19.0'}
+
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
 
   rfdc@1.4.1:
     resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
@@ -1207,6 +1503,10 @@ packages:
     resolution: {integrity: sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==}
     engines: {node: '>=11.0.0'}
 
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
+
   scule@1.3.0:
     resolution: {integrity: sha512-6FtHJEvt+pVMIB9IBY+IcCJ6Z5f1iQnytgyfKMhDKgmzYG+TeH/wx1y3l27rshSbLiSanrR9ffZDrEsmjlQF2g==}
 
@@ -1218,6 +1518,21 @@ packages:
     resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
     engines: {node: '>=10'}
     hasBin: true
+
+  shebang-command@2.0.0:
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    engines: {node: '>=8'}
+
+  shebang-regex@3.0.0:
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
+
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  signal-exit@4.1.0:
+    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
+    engines: {node: '>=14'}
 
   sirv@3.0.2:
     resolution: {integrity: sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==}
@@ -1231,8 +1546,30 @@ packages:
     resolution: {integrity: sha512-1POYv7uv2gXoyGFpBCmpDVSNV74IfsWlDW216UPjbWufNf+bSU6GdbDsxdcxtfwb4xlI3yxzOTKClUosxARYrQ==}
     engines: {node: '>=0.10.0'}
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+
+  std-env@4.0.0:
+    resolution: {integrity: sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==}
+
+  string-width@4.2.3:
+    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
+    engines: {node: '>=8'}
+
+  string-width@5.1.2:
+    resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
+    engines: {node: '>=12'}
+
+  strip-ansi@6.0.1:
+    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
+    engines: {node: '>=8'}
+
+  strip-ansi@7.2.0:
+    resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
+    engines: {node: '>=12'}
 
   strip-literal@3.1.0:
     resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
@@ -1246,12 +1583,18 @@ packages:
     engines: {node: '>=14.0.0'}
     hasBin: true
 
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
   tailwindcss@4.2.2:
     resolution: {integrity: sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q==}
 
   tapable@2.3.2:
     resolution: {integrity: sha512-1MOpMXuhGzGL5TTCZFItxCc0AARf1EZFQkGqMm7ERKj8+Hgr5oLvJOVFcC+lRmR8hCe2S3jC4T5D7Vg/d7/fhA==}
     engines: {node: '>=6'}
+
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
   tinyexec@1.0.4:
     resolution: {integrity: sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==}
@@ -1261,9 +1604,28 @@ packages:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
 
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
+
+  tldts-core@7.0.27:
+    resolution: {integrity: sha512-YQ7uPjgWUibIK6DW5lrKujGwUKhLevU4hcGbP5O6TcIUb+oTjJYJVWPS4nZsIHrEEEG6myk/oqAJUEQmpZrHsg==}
+
+  tldts@7.0.27:
+    resolution: {integrity: sha512-I4FZcVFcqCRuT0ph6dCDpPuO4Xgzvh+spkcTr1gK7peIvxWauoloVO0vuy1FQnijT63ss6AsHB6+OIM4aXHbPg==}
+    hasBin: true
+
   totalist@3.0.1:
     resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
     engines: {node: '>=6'}
+
+  tough-cookie@6.0.1:
+    resolution: {integrity: sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==}
+    engines: {node: '>=16'}
+
+  tr46@6.0.0:
+    resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
+    engines: {node: '>=20'}
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
@@ -1281,6 +1643,10 @@ packages:
 
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
+
+  undici@7.24.7:
+    resolution: {integrity: sha512-H/nlJ/h0ggGC+uRL3ovD+G0i4bqhvsDOpbDv7At5eFLlj2b41L8QliGbnl2H7SnDiYhENphh1tQFJZf+MyfLsQ==}
+    engines: {node: '>=20.18.1'}
 
   unimport@5.7.0:
     resolution: {integrity: sha512-njnL6sp8lEA8QQbZrt+52p/g4X0rw3bnGGmUcJnt1jeG8+iiqO779aGz0PirCtydAIVcuTBRlJ52F0u46z309Q==}
@@ -1402,6 +1768,44 @@ packages:
       yaml:
         optional: true
 
+  vitest@4.1.2:
+    resolution: {integrity: sha512-xjR1dMTVHlFLh98JE3i/f/WePqJsah4A0FK9cc8Ehp9Udk0AZk6ccpIZhh1qJ/yxVWRZ+Q54ocnD8TXmkhspGg==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.2
+      '@vitest/browser-preview': 4.1.2
+      '@vitest/browser-webdriverio': 4.1.2
+      '@vitest/ui': 4.1.2
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  vue-component-type-helpers@2.2.12:
+    resolution: {integrity: sha512-YbGqHZ5/eW4SnkPNR44mKVc6ZKQoRs/Rux1sxC6rdwXb4qpbOSYfDr9DsTHolOTGmIKgM9j141mZbBeg05R1pw==}
+
   vue-draggable-plus@0.6.1:
     resolution: {integrity: sha512-FbtQ/fuoixiOfTZzG3yoPl4JAo9HJXRHmBQZFB9x2NYCh6pq0TomHf7g5MUmpaDYv+LU2n6BPq2YN9sBO+FbIg==}
     peerDependencies:
@@ -1443,12 +1847,53 @@ packages:
       typescript:
         optional: true
 
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
+  webidl-conversions@8.0.1:
+    resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
+    engines: {node: '>=20'}
+
   webpack-virtual-modules@0.6.2:
     resolution: {integrity: sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==}
+
+  whatwg-mimetype@5.0.0:
+    resolution: {integrity: sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==}
+    engines: {node: '>=20'}
+
+  whatwg-url@16.0.1:
+    resolution: {integrity: sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  which@2.0.2:
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+
+  wrap-ansi@7.0.0:
+    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
+    engines: {node: '>=10'}
+
+  wrap-ansi@8.1.0:
+    resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
+    engines: {node: '>=12'}
 
   wsl-utils@0.1.0:
     resolution: {integrity: sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==}
     engines: {node: '>=18'}
+
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
@@ -1465,6 +1910,24 @@ snapshots:
   '@aptabase/tauri@0.4.1':
     dependencies:
       '@tauri-apps/api': 1.6.0
+
+  '@asamuzakjp/css-color@5.1.1':
+    dependencies:
+      '@csstools/css-calc': 3.1.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-color-parser': 4.0.2(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+      lru-cache: 11.2.7
+
+  '@asamuzakjp/dom-selector@7.0.4':
+    dependencies:
+      '@asamuzakjp/nwsapi': 2.3.9
+      bidi-js: 1.0.3
+      css-tree: 3.2.1
+      is-potential-custom-element-name: 1.0.1
+      lru-cache: 11.2.7
+
+  '@asamuzakjp/nwsapi@2.3.9': {}
 
   '@babel/code-frame@7.29.0':
     dependencies:
@@ -1659,6 +2122,34 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
 
+  '@bramus/specificity@2.4.2':
+    dependencies:
+      css-tree: 3.2.1
+
+  '@csstools/color-helpers@6.0.2': {}
+
+  '@csstools/css-calc@3.1.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-color-parser@4.0.2(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/color-helpers': 6.0.2
+      '@csstools/css-calc': 3.1.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.2(css-tree@3.2.1)':
+    optionalDependencies:
+      css-tree: 3.2.1
+
+  '@csstools/css-tokenizer@4.0.0': {}
+
   '@emnapi/core@1.9.1':
     dependencies:
       '@emnapi/wasi-threads': 1.2.0
@@ -1674,6 +2165,8 @@ snapshots:
     dependencies:
       tslib: 2.8.1
     optional: true
+
+  '@exodus/bytes@1.15.0': {}
 
   '@intlify/core-base@11.3.0':
     dependencies:
@@ -1692,6 +2185,15 @@ snapshots:
       source-map-js: 1.2.1
 
   '@intlify/shared@11.3.0': {}
+
+  '@isaacs/cliui@8.0.2':
+    dependencies:
+      string-width: 5.1.2
+      string-width-cjs: string-width@4.2.3
+      strip-ansi: 7.2.0
+      strip-ansi-cjs: strip-ansi@6.0.1
+      wrap-ansi: 8.1.0
+      wrap-ansi-cjs: wrap-ansi@7.0.0
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
@@ -1747,7 +2249,12 @@ snapshots:
       - magicast
     optional: true
 
+  '@one-ini/wasm@0.1.1': {}
+
   '@oxc-project/types@0.122.0': {}
+
+  '@pkgjs/parseargs@0.11.0':
+    optional: true
 
   '@polka/url@1.0.0-next.29': {}
 
@@ -1804,6 +2311,8 @@ snapshots:
   '@rolldown/pluginutils@1.0.0-rc.12': {}
 
   '@rolldown/pluginutils@1.0.0-rc.2': {}
+
+  '@standard-schema/spec@1.1.0': {}
 
   '@tailwindcss/node@4.2.2':
     dependencies:
@@ -1918,8 +2427,14 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@types/estree@1.0.8':
-    optional: true
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
+
+  '@types/estree@1.0.8': {}
 
   '@types/node@25.5.0':
     dependencies:
@@ -1954,6 +2469,47 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-rc.2
       vite: 8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.5.0)(jiti@2.6.1)(yaml@2.8.3)
       vue: 3.5.31(typescript@6.0.2)
+
+  '@vitest/expect@4.1.2':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.2
+      '@vitest/utils': 4.1.2
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.2(vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.5.0)(jiti@2.6.1)(yaml@2.8.3))':
+    dependencies:
+      '@vitest/spy': 4.1.2
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.5.0)(jiti@2.6.1)(yaml@2.8.3)
+
+  '@vitest/pretty-format@4.1.2':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.2':
+    dependencies:
+      '@vitest/utils': 4.1.2
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.2':
+    dependencies:
+      '@vitest/pretty-format': 4.1.2
+      '@vitest/utils': 4.1.2
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.2': {}
+
+  '@vitest/utils@4.1.2':
+    dependencies:
+      '@vitest/pretty-format': 4.1.2
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
 
   '@vue-macros/common@3.1.2(vue@3.5.31(typescript@6.0.2))':
     dependencies:
@@ -2087,7 +2643,14 @@ snapshots:
 
   '@vue/shared@3.5.31': {}
 
+  '@vue/test-utils@2.4.6':
+    dependencies:
+      js-beautify: 1.15.4
+      vue-component-type-helpers: 2.2.12
+
   '@xmldom/xmldom@0.8.11': {}
+
+  abbrev@2.0.0: {}
 
   acorn@8.16.0: {}
 
@@ -2098,7 +2661,19 @@ snapshots:
       global: 4.4.0
       pkcs7: 1.0.4
 
+  ansi-regex@5.0.1: {}
+
+  ansi-regex@6.2.2: {}
+
+  ansi-styles@4.3.0:
+    dependencies:
+      color-convert: 2.0.1
+
+  ansi-styles@6.2.3: {}
+
   ansis@4.2.0: {}
+
+  assertion-error@2.0.1: {}
 
   ast-kit@2.2.0:
     dependencies:
@@ -2119,11 +2694,21 @@ snapshots:
       postcss: 8.5.8
       postcss-value-parser: 4.2.0
 
+  balanced-match@1.0.2: {}
+
   baseline-browser-mapping@2.10.12: {}
+
+  bidi-js@1.0.3:
+    dependencies:
+      require-from-string: 2.0.2
 
   birpc@2.9.0: {}
 
   boolbase@1.0.0: {}
+
+  brace-expansion@2.0.3:
+    dependencies:
+      balanced-match: 1.0.2
 
   browserslist@4.28.1:
     dependencies:
@@ -2155,6 +2740,8 @@ snapshots:
 
   caniuse-lite@1.0.30001781: {}
 
+  chai@6.2.2: {}
+
   chokidar@5.0.0:
     dependencies:
       readdirp: 5.0.0
@@ -2167,11 +2754,24 @@ snapshots:
   citty@0.2.1:
     optional: true
 
+  color-convert@2.0.1:
+    dependencies:
+      color-name: 1.1.4
+
+  color-name@1.1.4: {}
+
+  commander@10.0.1: {}
+
   commander@7.2.0: {}
 
   confbox@0.1.8: {}
 
   confbox@0.2.4: {}
+
+  config-chain@1.1.13:
+    dependencies:
+      ini: 1.3.8
+      proto-list: 1.2.4
 
   consola@3.4.2:
     optional: true
@@ -2181,6 +2781,12 @@ snapshots:
   copy-anything@4.0.5:
     dependencies:
       is-what: 5.5.0
+
+  cross-spawn@7.0.6:
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
 
   css-select@5.2.2:
     dependencies:
@@ -2200,6 +2806,11 @@ snapshots:
       mdn-data: 2.0.30
       source-map-js: 1.2.1
 
+  css-tree@3.2.1:
+    dependencies:
+      mdn-data: 2.27.1
+      source-map-js: 1.2.1
+
   css-what@6.2.2: {}
 
   csso@5.0.5:
@@ -2210,11 +2821,20 @@ snapshots:
 
   daisyui@5.5.19: {}
 
+  data-urls@7.0.0:
+    dependencies:
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
   date-fns@4.1.0: {}
 
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
+
+  decimal.js@10.6.0: {}
 
   default-browser-id@5.0.1: {}
 
@@ -2255,7 +2875,20 @@ snapshots:
   dotenv@17.3.1:
     optional: true
 
+  eastasianwidth@0.2.0: {}
+
+  editorconfig@1.0.7:
+    dependencies:
+      '@one-ini/wasm': 0.1.1
+      commander: 10.0.1
+      minimatch: 9.0.9
+      semver: 7.7.4
+
   electron-to-chromium@1.5.328: {}
+
+  emoji-regex@8.0.0: {}
+
+  emoji-regex@9.2.2: {}
 
   enhanced-resolve@5.20.1:
     dependencies:
@@ -2264,12 +2897,16 @@ snapshots:
 
   entities@4.5.0: {}
 
+  entities@6.0.1: {}
+
   entities@7.0.1: {}
 
   error-stack-parser-es@1.0.5: {}
 
   errx@0.1.0:
     optional: true
+
+  es-module-lexer@2.0.0: {}
 
   escalade@3.2.0: {}
 
@@ -2281,13 +2918,19 @@ snapshots:
   estree-walker@3.0.3:
     dependencies:
       '@types/estree': 1.0.8
-    optional: true
+
+  expect-type@1.3.0: {}
 
   exsolve@1.0.8: {}
 
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
+
+  foreground-child@3.3.1:
+    dependencies:
+      cross-spawn: 7.0.6
+      signal-exit: 4.1.0
 
   fraction.js@5.3.4: {}
 
@@ -2306,6 +2949,15 @@ snapshots:
       pathe: 2.0.3
     optional: true
 
+  glob@10.5.0:
+    dependencies:
+      foreground-child: 3.3.1
+      jackspeak: 3.4.3
+      minimatch: 9.0.9
+      minipass: 7.1.3
+      package-json-from-dist: 1.0.1
+      path-scurry: 1.11.1
+
   global@4.4.0:
     dependencies:
       min-document: 2.19.2
@@ -2315,10 +2967,20 @@ snapshots:
 
   hookable@5.5.3: {}
 
+  html-encoding-sniffer@6.0.0:
+    dependencies:
+      '@exodus/bytes': 1.15.0
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
   ignore@7.0.5:
     optional: true
 
+  ini@1.3.8: {}
+
   is-docker@3.0.0: {}
+
+  is-fullwidth-code-point@3.0.0: {}
 
   is-function@1.0.2: {}
 
@@ -2326,18 +2988,64 @@ snapshots:
     dependencies:
       is-docker: 3.0.0
 
+  is-potential-custom-element-name@1.0.1: {}
+
   is-what@5.5.0: {}
 
   is-wsl@3.1.1:
     dependencies:
       is-inside-container: 1.0.0
 
+  isexe@2.0.0: {}
+
+  jackspeak@3.4.3:
+    dependencies:
+      '@isaacs/cliui': 8.0.2
+    optionalDependencies:
+      '@pkgjs/parseargs': 0.11.0
+
   jiti@2.6.1: {}
+
+  js-beautify@1.15.4:
+    dependencies:
+      config-chain: 1.1.13
+      editorconfig: 1.0.7
+      glob: 10.5.0
+      js-cookie: 3.0.5
+      nopt: 7.2.1
+
+  js-cookie@3.0.5: {}
 
   js-tokens@4.0.0: {}
 
   js-tokens@9.0.1:
     optional: true
+
+  jsdom@29.0.1:
+    dependencies:
+      '@asamuzakjp/css-color': 5.1.1
+      '@asamuzakjp/dom-selector': 7.0.4
+      '@bramus/specificity': 2.4.2
+      '@csstools/css-syntax-patches-for-csstree': 1.1.2(css-tree@3.2.1)
+      '@exodus/bytes': 1.15.0
+      css-tree: 3.2.1
+      data-urls: 7.0.0
+      decimal.js: 10.6.0
+      html-encoding-sniffer: 6.0.0
+      is-potential-custom-element-name: 1.0.1
+      lru-cache: 11.2.7
+      parse5: 8.0.0
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 6.0.1
+      undici: 7.24.7
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 8.0.1
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   jsesc@3.1.0: {}
 
@@ -2410,6 +3118,10 @@ snapshots:
 
   lodash@4.17.23: {}
 
+  lru-cache@10.4.3: {}
+
+  lru-cache@11.2.7: {}
+
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
@@ -2432,9 +3144,17 @@ snapshots:
 
   mdn-data@2.0.30: {}
 
+  mdn-data@2.27.1: {}
+
   min-document@2.19.2:
     dependencies:
       dom-walk: 0.1.2
+
+  minimatch@9.0.9:
+    dependencies:
+      brace-expansion: 2.0.3
+
+  minipass@7.1.3: {}
 
   mitt@3.0.1: {}
 
@@ -2470,6 +3190,10 @@ snapshots:
 
   node-releases@2.0.36: {}
 
+  nopt@7.2.1:
+    dependencies:
+      abbrev: 2.0.0
+
   nth-check@2.1.1:
     dependencies:
       boolbase: 1.0.0
@@ -2481,6 +3205,8 @@ snapshots:
       tinyexec: 1.0.4
     optional: true
 
+  obug@2.1.1: {}
+
   ohash@2.0.11: {}
 
   open@10.2.0:
@@ -2489,6 +3215,19 @@ snapshots:
       define-lazy-prop: 3.0.0
       is-inside-container: 1.0.0
       wsl-utils: 0.1.0
+
+  package-json-from-dist@1.0.1: {}
+
+  parse5@8.0.0:
+    dependencies:
+      entities: 6.0.1
+
+  path-key@3.1.1: {}
+
+  path-scurry@1.11.1:
+    dependencies:
+      lru-cache: 10.4.3
+      minipass: 7.1.3
 
   pathe@2.0.3: {}
 
@@ -2542,6 +3281,10 @@ snapshots:
 
   process@0.11.10: {}
 
+  proto-list@1.2.4: {}
+
+  punycode@2.3.1: {}
+
   quansync@0.2.11: {}
 
   rc9@2.1.2:
@@ -2551,6 +3294,8 @@ snapshots:
     optional: true
 
   readdirp@5.0.0: {}
+
+  require-from-string@2.0.2: {}
 
   rfdc@1.4.1: {}
 
@@ -2582,12 +3327,25 @@ snapshots:
 
   sax@1.6.0: {}
 
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
+
   scule@1.3.0: {}
 
   semver@6.3.1: {}
 
-  semver@7.7.4:
-    optional: true
+  semver@7.7.4: {}
+
+  shebang-command@2.0.0:
+    dependencies:
+      shebang-regex: 3.0.0
+
+  shebang-regex@3.0.0: {}
+
+  siginfo@2.0.0: {}
+
+  signal-exit@4.1.0: {}
 
   sirv@3.0.2:
     dependencies:
@@ -2599,8 +3357,32 @@ snapshots:
 
   speakingurl@14.0.1: {}
 
+  stackback@0.0.2: {}
+
   std-env@3.10.0:
     optional: true
+
+  std-env@4.0.0: {}
+
+  string-width@4.2.3:
+    dependencies:
+      emoji-regex: 8.0.0
+      is-fullwidth-code-point: 3.0.0
+      strip-ansi: 6.0.1
+
+  string-width@5.1.2:
+    dependencies:
+      eastasianwidth: 0.2.0
+      emoji-regex: 9.2.2
+      strip-ansi: 7.2.0
+
+  strip-ansi@6.0.1:
+    dependencies:
+      ansi-regex: 5.0.1
+
+  strip-ansi@7.2.0:
+    dependencies:
+      ansi-regex: 6.2.2
 
   strip-literal@3.1.0:
     dependencies:
@@ -2621,19 +3403,38 @@ snapshots:
       picocolors: 1.1.1
       sax: 1.6.0
 
+  symbol-tree@3.2.4: {}
+
   tailwindcss@4.2.2: {}
 
   tapable@2.3.2: {}
 
-  tinyexec@1.0.4:
-    optional: true
+  tinybench@2.9.0: {}
+
+  tinyexec@1.0.4: {}
 
   tinyglobby@0.2.15:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
 
+  tinyrainbow@3.1.0: {}
+
+  tldts-core@7.0.27: {}
+
+  tldts@7.0.27:
+    dependencies:
+      tldts-core: 7.0.27
+
   totalist@3.0.1: {}
+
+  tough-cookie@6.0.1:
+    dependencies:
+      tldts: 7.0.27
+
+  tr46@6.0.0:
+    dependencies:
+      punycode: 2.3.1
 
   tslib@2.8.1:
     optional: true
@@ -2651,6 +3452,8 @@ snapshots:
     optional: true
 
   undici-types@7.18.2: {}
+
+  undici@7.24.7: {}
 
   unimport@5.7.0:
     dependencies:
@@ -2810,6 +3613,36 @@ snapshots:
       - '@emnapi/core'
       - '@emnapi/runtime'
 
+  vitest@4.1.2(@types/node@25.5.0)(jsdom@29.0.1)(vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.5.0)(jiti@2.6.1)(yaml@2.8.3)):
+    dependencies:
+      '@vitest/expect': 4.1.2
+      '@vitest/mocker': 4.1.2(vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.5.0)(jiti@2.6.1)(yaml@2.8.3))
+      '@vitest/pretty-format': 4.1.2
+      '@vitest/runner': 4.1.2
+      '@vitest/snapshot': 4.1.2
+      '@vitest/spy': 4.1.2
+      '@vitest/utils': 4.1.2
+      es-module-lexer: 2.0.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.0.0
+      tinybench: 2.9.0
+      tinyexec: 1.0.4
+      tinyglobby: 0.2.15
+      tinyrainbow: 3.1.0
+      vite: 8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.5.0)(jiti@2.6.1)(yaml@2.8.3)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 25.5.0
+      jsdom: 29.0.1
+    transitivePeerDependencies:
+      - msw
+
+  vue-component-type-helpers@2.2.12: {}
+
   vue-draggable-plus@0.6.1(@types/sortablejs@1.15.8):
     dependencies:
       '@types/sortablejs': 1.15.8
@@ -2858,11 +3691,52 @@ snapshots:
     optionalDependencies:
       typescript: 6.0.2
 
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
+
+  webidl-conversions@8.0.1: {}
+
   webpack-virtual-modules@0.6.2: {}
+
+  whatwg-mimetype@5.0.0: {}
+
+  whatwg-url@16.0.1:
+    dependencies:
+      '@exodus/bytes': 1.15.0
+      tr46: 6.0.0
+      webidl-conversions: 8.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
+  which@2.0.2:
+    dependencies:
+      isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
+
+  wrap-ansi@7.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
+  wrap-ansi@8.1.0:
+    dependencies:
+      ansi-styles: 6.2.3
+      string-width: 5.1.2
+      strip-ansi: 7.2.0
 
   wsl-utils@0.1.0:
     dependencies:
       is-wsl: 3.1.1
+
+  xml-name-validator@5.0.0: {}
+
+  xmlchars@2.2.0: {}
 
   yallist@3.1.1: {}
 

--- a/src-vite/src/common/api.js
+++ b/src-vite/src/common/api.js
@@ -87,6 +87,26 @@ export async function switchLibrary(id) {
   }
 }
 
+// move a library database to a different storage folder
+export async function moveLibraryStorage(id, storageDir = null) {
+  try {
+    return await invoke('move_library_storage', { id, storageDir });
+  } catch (error) {
+    console.error('Failed to move library storage:', error);
+    throw error;
+  }
+}
+
+export async function cancelLibraryStorageMove(id) {
+  try {
+    await invoke('cancel_library_storage_move', { id });
+    return true;
+  } catch (error) {
+    console.error('Failed to cancel library storage move:', error);
+    throw error;
+  }
+}
+
 // get library info
 export async function getLibraryInfo(id) {
   try {
@@ -1143,12 +1163,16 @@ export async function dedupStartScan(params = null) {
 }
 
 // get deduplication scan status
-export async function dedupGetScanStatus() {
+export async function dedupGetScanStatus(options = {}) {
+  const strict = Boolean(options?.strict);
   try {
     const status = await invoke('dedup_get_scan_status');
     return status;
   } catch (error) {
     console.error('dedupGetScanStatus error:', error);
+    if (strict) {
+      throw error;
+    }
   }
 }
 
@@ -1217,9 +1241,27 @@ export async function listenDedupScanProgress(callback) {
   return await listen('dedup-scan-progress', callback);
 }
 
+// listen library storage move progress
+export async function listenLibraryStorageMoveProgress(callback) {
+  return await listen('library-storage-move-progress', callback);
+}
+
 // listen index finished
 export async function listenIndexFinished(callback) {
   return await listen('index_finished', callback);
+}
+
+export async function getIndexingActivity(options = {}) {
+  const strict = Boolean(options?.strict);
+  try {
+    return await invoke('get_indexing_activity');
+  } catch (error) {
+    console.error('Failed to get indexing activity:', error);
+    if (strict) {
+      throw error;
+    }
+    return { running: false, albumId: null };
+  }
 }
 
 // index faces for all images in library
@@ -1254,11 +1296,15 @@ export async function resetFaces() {
 }
 
 // check if face indexing is running
-export async function isFaceIndexing() {
+export async function isFaceIndexing(options = {}) {
+  const strict = Boolean(options?.strict);
   try {
     return await invoke('is_face_indexing');
   } catch (error) {
     console.error('Failed to check face indexing status:', error);
+    if (strict) {
+      throw error;
+    }
     return false;
   }
 }

--- a/src-vite/src/common/libraryMove.js
+++ b/src-vite/src/common/libraryMove.js
@@ -1,0 +1,133 @@
+export const LIBRARY_MOVE_CANCELLED_ERROR = 'Library storage move cancelled.';
+
+export const sleep = (ms) => new Promise((resolve) => window.setTimeout(resolve, ms));
+
+export function isFaceIndexingRunning(result) {
+  return Array.isArray(result) ? Boolean(result[0]) : Boolean(result);
+}
+
+export async function waitForActivityIdle(
+  fetchStatus,
+  isRunning,
+  timeoutMessage,
+  options = {}
+) {
+  const timeoutMs = Number(options.timeoutMs || 10000);
+  const pollMs = Number(options.pollMs || 200);
+  const sleepFn = options.sleepFn || sleep;
+  const startedAt = Date.now();
+
+  while (Date.now() - startedAt < timeoutMs) {
+    const status = await fetchStatus();
+    if (!isRunning(status)) {
+      return status;
+    }
+    await sleepFn(pollMs);
+  }
+
+  throw new Error(timeoutMessage);
+}
+
+export async function waitForIndexingIdle(getIndexingActivity, options = {}) {
+  return waitForActivityIdle(
+    () => getIndexingActivity({ strict: true }),
+    (activity) => Boolean(activity?.running),
+    'Timed out while waiting for indexing to stop.',
+    options
+  );
+}
+
+export async function waitForDedupIdle(dedupGetScanStatus, options = {}) {
+  return waitForActivityIdle(
+    () => dedupGetScanStatus({ strict: true }),
+    (status) => status?.state === 'running',
+    'Timed out while waiting for dedup scan to stop.',
+    options
+  );
+}
+
+export async function waitForFaceIndexIdle(isFaceIndexing, options = {}) {
+  return waitForActivityIdle(
+    () => isFaceIndexing({ strict: true }),
+    isFaceIndexingRunning,
+    'Timed out while waiting for face indexing to stop.',
+    options
+  );
+}
+
+export function createIndexMoveSnapshot(indexState) {
+  const queueSnapshot = Array.isArray(indexState?.albumQueue)
+    ? [...indexState.albumQueue]
+    : [];
+  const pausedSnapshot = Array.isArray(indexState?.pausedAlbumIds)
+    ? [...indexState.pausedAlbumIds]
+    : [];
+
+  return {
+    indexQueue: queueSnapshot,
+    pausedAlbumIds: pausedSnapshot,
+    indexStatus: Number(indexState?.status || 0),
+    activeAlbumId: Number(queueSnapshot[0] || 0),
+  };
+}
+
+export function pauseIndexStateForLibraryMove(indexState, snapshot = createIndexMoveSnapshot(indexState)) {
+  if (!indexState || !snapshot.indexQueue.length) {
+    return snapshot;
+  }
+
+  indexState.albumQueue = [];
+  indexState.pausedAlbumIds = Array.from(
+    new Set([...snapshot.pausedAlbumIds, ...snapshot.indexQueue].map((id) => Number(id)).filter((id) => id > 0))
+  );
+  indexState.status = 2;
+  return snapshot;
+}
+
+export function restoreIndexStateAfterLibraryMove(indexState, snapshot) {
+  if (!indexState || !snapshot || typeof snapshot !== 'object') {
+    return;
+  }
+
+  indexState.pausedAlbumIds = Array.isArray(snapshot.pausedAlbumIds)
+    ? [...snapshot.pausedAlbumIds]
+    : [];
+  indexState.albumQueue = Array.isArray(snapshot.indexQueue)
+    ? [...snapshot.indexQueue]
+    : [];
+
+  if (indexState.albumQueue.length > 0) {
+    indexState.status = Number(snapshot.indexStatus || 0) === 1 ? 1 : 2;
+  } else {
+    indexState.status = Number(snapshot.indexStatus || 0);
+  }
+}
+
+export function shouldResumeDedup(snapshot) {
+  return Boolean(
+    snapshot &&
+    snapshot.dedupWasRunning &&
+    snapshot.dedupStoppedCleanly &&
+    snapshot.dedupParams
+  );
+}
+
+export function shouldResumeFace(faceMoveState) {
+  return Boolean(
+    faceMoveState &&
+    faceMoveState.wasRunning &&
+    faceMoveState.stoppedCleanly
+  );
+}
+
+export function pickLibraryMoveError(primaryError, cleanupError) {
+  return primaryError || cleanupError || null;
+}
+
+export function requiresConnectedMetadataStorage(libraryInfo) {
+  return Boolean(
+    libraryInfo &&
+    libraryInfo.storageAvailable === false &&
+    libraryInfo.metadataInitialized
+  );
+}

--- a/src-vite/src/common/libraryMove.test.js
+++ b/src-vite/src/common/libraryMove.test.js
@@ -1,0 +1,122 @@
+import {
+  createIndexMoveSnapshot,
+  isFaceIndexingRunning,
+  pickLibraryMoveError,
+  requiresConnectedMetadataStorage,
+  restoreIndexStateAfterLibraryMove,
+  shouldResumeDedup,
+  shouldResumeFace,
+  waitForDedupIdle,
+  waitForFaceIndexIdle,
+  waitForIndexingIdle,
+} from './libraryMove';
+
+describe('libraryMove helpers', () => {
+  it('fails closed when indexing activity lookup throws', async () => {
+    await expect(
+      waitForIndexingIdle(() => {
+        throw new Error('bridge down');
+      }, { timeoutMs: 50, pollMs: 1 })
+    ).rejects.toThrow('bridge down');
+  });
+
+  it('fails closed when dedup status lookup throws', async () => {
+    await expect(
+      waitForDedupIdle(() => {
+        throw new Error('dedup unavailable');
+      }, { timeoutMs: 50, pollMs: 1 })
+    ).rejects.toThrow('dedup unavailable');
+  });
+
+  it('fails closed when face indexing lookup throws', async () => {
+    await expect(
+      waitForFaceIndexIdle(() => {
+        throw new Error('face unavailable');
+      }, { timeoutMs: 50, pollMs: 1 })
+    ).rejects.toThrow('face unavailable');
+  });
+
+  it('restores index queue and status after move', () => {
+    const indexState = {
+      status: 1,
+      albumQueue: [11, 22],
+      pausedAlbumIds: [33],
+    };
+
+    const snapshot = createIndexMoveSnapshot(indexState);
+    indexState.status = 2;
+    indexState.albumQueue = [];
+    indexState.pausedAlbumIds = [11, 22, 33];
+
+    restoreIndexStateAfterLibraryMove(indexState, snapshot);
+
+    expect(indexState).toEqual({
+      status: 1,
+      albumQueue: [11, 22],
+      pausedAlbumIds: [33],
+    });
+  });
+
+  it('detects disconnected metadata that must reconnect first', () => {
+    expect(
+      requiresConnectedMetadataStorage({
+        storageAvailable: false,
+        metadataInitialized: true,
+      })
+    ).toBe(true);
+    expect(
+      requiresConnectedMetadataStorage({
+        storageAvailable: false,
+        metadataInitialized: false,
+      })
+    ).toBe(false);
+  });
+
+  it('only resumes dedup after a clean stop', () => {
+    expect(
+      shouldResumeDedup({
+        dedupWasRunning: true,
+        dedupStoppedCleanly: false,
+        dedupParams: { path: 'x' },
+      })
+    ).toBe(false);
+
+    expect(
+      shouldResumeDedup({
+        dedupWasRunning: true,
+        dedupStoppedCleanly: true,
+        dedupParams: { path: 'x' },
+      })
+    ).toBe(true);
+  });
+
+  it('only resumes face indexing after a clean stop', () => {
+    expect(
+      shouldResumeFace({
+        wasRunning: true,
+        stoppedCleanly: false,
+      })
+    ).toBe(false);
+
+    expect(
+      shouldResumeFace({
+        wasRunning: true,
+        stoppedCleanly: true,
+      })
+    ).toBe(true);
+  });
+
+  it('keeps the primary move error when cleanup also fails', () => {
+    const primaryError = new Error('move failed');
+    const cleanupError = new Error('resume failed');
+
+    expect(pickLibraryMoveError(primaryError, cleanupError)).toBe(primaryError);
+    expect(pickLibraryMoveError(null, cleanupError)).toBe(cleanupError);
+  });
+
+  it('normalizes face indexing responses', () => {
+    expect(isFaceIndexingRunning([true, null])).toBe(true);
+    expect(isFaceIndexingRunning([false, null])).toBe(false);
+    expect(isFaceIndexingRunning(true)).toBe(true);
+  });
+});

--- a/src-vite/src/components/Content.vue
+++ b/src-vite/src/components/Content.vue
@@ -567,8 +567,17 @@ import { getAlbum, recountAlbum, getQueryCountAndSum, getQueryTimeLine, getQuery
          revealFolder, getTagName, indexAlbum, listenIndexProgress, listenIndexFinished, setAlbumCover,
          updateFileInfo, addFileToDb, cancelIndexing as cancelIndexingApi, selectFolder, getFacesForFile, listenFaceIndexProgress,
          openFileWithApp, getIndexRecoveryInfo, clearIndexRecoveryInfo,
-         dedupGetGroup, dedupDeleteSelected, getQueryFilePosition } from '@/common/api'; 
+         dedupGetGroup, dedupDeleteSelected, dedupStartScan, dedupGetScanStatus, dedupCancelScan,
+         getQueryFilePosition, getIndexingActivity } from '@/common/api';
 import { config, libConfig } from '@/common/config';
+import {
+  createIndexMoveSnapshot,
+  pauseIndexStateForLibraryMove,
+  restoreIndexStateAfterLibraryMove,
+  shouldResumeDedup,
+  waitForDedupIdle,
+  waitForIndexingIdle,
+} from '@/common/libraryMove';
 import { getSmartTagById, SMART_TAG_SEARCH_THRESHOLD } from '@/common/smartTags';
 import { getAlbumScanState, getAlbumScanIcon, shouldAnimateAlbumScanIcon } from '@/common/scanStatus';
 import { isWin, isMac, setTheme, separator,
@@ -2179,6 +2188,54 @@ async function cancelIndexing() {
       (libConfig.index.pausedAlbumIds as any[]).push(Number(albumId || 0));
     }
     syncIndexStatus();
+  }
+}
+
+async function prepareForLibraryStorageMove() {
+  const indexSnapshot = createIndexMoveSnapshot(libConfig.index);
+  const snapshot = {
+    ...indexSnapshot,
+    dedupWasRunning: false,
+    dedupStoppedCleanly: false,
+    dedupParams: null,
+  };
+
+  try {
+    pauseIndexStateForLibraryMove(libConfig.index, indexSnapshot);
+
+    if (indexSnapshot.activeAlbumId > 0 && indexSnapshot.indexStatus === 1) {
+      await cancelIndexingApi(indexSnapshot.activeAlbumId);
+      await waitForIndexingIdle(getIndexingActivity);
+    }
+
+    const dedupStatus = await dedupGetScanStatus({ strict: true });
+    const dedupWasRunning = dedupStatus?.state === 'running';
+    const dedupParams = dedupWasRunning ? { ...dedupQueryParams.value } : null;
+    snapshot.dedupWasRunning = dedupWasRunning;
+    snapshot.dedupParams = dedupParams;
+
+    if (dedupWasRunning) {
+      await dedupCancelScan();
+      await waitForDedupIdle(dedupGetScanStatus);
+      snapshot.dedupStoppedCleanly = true;
+    }
+
+    return snapshot;
+  } catch (error: any) {
+    if (error && typeof error === 'object') {
+      error.libraryMoveSnapshot = snapshot;
+    }
+    throw error;
+  }
+}
+
+async function resumeAfterLibraryStorageMove(snapshot: any) {
+  if (!snapshot || typeof snapshot !== 'object') return;
+
+  restoreIndexStateAfterLibraryMove(libConfig.index, snapshot);
+
+  if (shouldResumeDedup(snapshot)) {
+    await dedupStartScan(snapshot.dedupParams);
   }
 }
 
@@ -4613,4 +4670,9 @@ function stopDragging() {
   document.removeEventListener('mousemove', handleMouseMove);
   document.removeEventListener('mouseup', stopDragging);
 }
+
+defineExpose({
+  prepareForLibraryStorageMove,
+  resumeAfterLibraryStorageMove,
+});
 </script>

--- a/src-vite/src/components/ManageLibraries.test.js
+++ b/src-vite/src/components/ManageLibraries.test.js
@@ -1,0 +1,123 @@
+import { ref } from 'vue';
+import { shallowMount } from '@vue/test-utils';
+
+const getAppConfigMock = vi.fn();
+const getLibraryInfoMock = vi.fn();
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({
+    t: (key) => key,
+    locale: ref('en'),
+    messages: ref({ en: { msgbox: { manage_libraries: {} } } }),
+  }),
+}));
+
+vi.mock('@/stores/uiStore', () => ({
+  useUIStore: () => ({
+    pushInputHandler: vi.fn(),
+    popInputHandler: vi.fn(),
+  }),
+}));
+
+vi.mock('@/common/config', () => ({
+  config: {
+    main: {
+      maxLibraryCount: 10,
+    },
+  },
+}));
+
+vi.mock('@/common/api', () => ({
+  getAppConfig: (...args) => getAppConfigMock(...args),
+  getLibraryInfo: (...args) => getLibraryInfoMock(...args),
+  addLibrary: vi.fn(),
+  editLibrary: vi.fn(),
+  removeLibrary: vi.fn(),
+  hideLibrary: vi.fn(),
+  reorderLibraries: vi.fn(),
+  switchLibrary: vi.fn(),
+}));
+
+vi.mock('@/common/utils', () => ({
+  formatTimestamp: () => '',
+  isValidFileName: () => true,
+  formatFileSize: () => '',
+  openFolderDialog: vi.fn(),
+}));
+
+import ManageLibraries from './ManageLibraries.vue';
+
+const flushPromises = async () => {
+  await Promise.resolve();
+  await new Promise((resolve) => setTimeout(resolve, 0));
+};
+
+function createWrapper() {
+  return shallowMount(ManageLibraries, {
+    global: {
+      mocks: {
+        $t: (key) => key,
+      },
+      stubs: {
+        ModalDialog: { template: '<div><slot /></div>' },
+        MessageBox: true,
+        ProgressBar: true,
+        VueDraggable: { template: '<div><slot /></div>' },
+        TButton: {
+          props: ['disabled', 'tooltip'],
+          template: '<button :data-tooltip="tooltip" :data-disabled="String(disabled)"><slot /></button>',
+        },
+      },
+    },
+  });
+}
+
+describe('ManageLibraries', () => {
+  it('disables delete for disconnected libraries that still have metadata', async () => {
+    getAppConfigMock.mockResolvedValue({
+      current_library_id: 'default',
+      libraries: [
+        { id: 'default', name: 'Default Library', created_at: 1, hidden: false },
+        { id: 'blocked', name: 'Blocked Library', created_at: 2, hidden: false },
+        { id: 'healthy', name: 'Healthy Library', created_at: 3, hidden: false },
+      ],
+    });
+
+    getLibraryInfoMock.mockImplementation(async (id) => {
+      if (id === 'blocked') {
+        return {
+          dbFileSize: 0,
+          fileCount: 0,
+          totalSize: 0,
+          storageAvailable: false,
+          metadataInitialized: true,
+          usesDefaultStorage: false,
+          storageDir: '/Volumes/External/blocked',
+          dbFilePath: '/Volumes/External/blocked.db',
+        };
+      }
+      return {
+        dbFileSize: 1024,
+        fileCount: 12,
+        totalSize: 2048,
+        storageAvailable: true,
+        metadataInitialized: true,
+        usesDefaultStorage: true,
+        storageDir: '/tmp',
+        dbFilePath: `/tmp/${id}.db`,
+      };
+    });
+
+    const wrapper = createWrapper();
+    await vi.waitFor(() => {
+      expect(getLibraryInfoMock).toHaveBeenCalledTimes(3);
+    });
+    await flushPromises();
+
+    const deleteButtons = wrapper
+      .findAll('button[data-tooltip="msgbox.manage_libraries.delete"]')
+      .map((button) => button.attributes('data-disabled'));
+
+    expect(deleteButtons).toEqual(['true', 'true', 'false']);
+  });
+});

--- a/src-vite/src/components/ManageLibraries.vue
+++ b/src-vite/src/components/ManageLibraries.vue
@@ -18,7 +18,7 @@
         class="flex-1 overflow-x-hidden overflow-y-auto p-1 rounded-box select-none"
         :animation="200"
         handle=".drag-handle"
-        :disabled="showAddInput || isRenaming"
+        :disabled="showAddInput || isRenaming || isMovingStorage"
         @end="onDragEnd"
       >
         <div 
@@ -30,7 +30,7 @@
             selectedLibraryId === lib.id
               ? 'text-base-content bg-base-100 hover:bg-base-100 selected-item'
               : 'text-base-content/70 hover:bg-base-100/30',
-            showAddInput || (isRenaming && editingId !== lib.id) ? 'opacity-50' : 'cursor-pointer',
+            showAddInput || isMovingStorage || (isRenaming && editingId !== lib.id) ? 'opacity-50' : 'cursor-pointer',
           ]"
           @click="selectLibrary(lib)"
         >
@@ -79,35 +79,121 @@
             <TButton
               :icon="IconEdit"
               :buttonSize="'small'"
-              :disabled="showAddInput || isRenaming"
+              :disabled="showAddInput || isRenaming || isMovingStorage"
               :tooltip="$t('msgbox.manage_libraries.rename')"
               @click.stop="startRename(lib)"
             />
             <TButton
               :icon="lib.hidden ? IconHide : IconUnhide"
               :buttonSize="'small'"
-              :disabled="lib.id === 'default' || showAddInput || isRenaming"
+              :disabled="lib.id === 'default' || showAddInput || isRenaming || isMovingStorage"
               :tooltip="lib.hidden ? $t('msgbox.manage_libraries.show') : $t('msgbox.manage_libraries.hide')"
               @click.stop="toggleVisibility(lib)"
             />
             <TButton
               :icon="IconTrash"
               :buttonSize="'small'"
-              :disabled="lib.id === 'default' || showAddInput || isRenaming"
+              :disabled="isDeleteDisabled(lib)"
               :tooltip="$t('msgbox.manage_libraries.delete')"
               @click.stop="confirmDelete(lib)"
             />
-            <div class="drag-handle cursor-move" :class="{ 'cursor-not-allowed opacity-50': showAddInput || isRenaming }">
+            <div class="drag-handle cursor-move" :class="{ 'cursor-not-allowed opacity-50': showAddInput || isRenaming || isMovingStorage }">
               <TButton
                 :icon="IconDragHandle"
                 :buttonSize="'small'"
-                :disabled="showAddInput || isRenaming"
+                :disabled="showAddInput || isRenaming || isMovingStorage"
                 :tooltip="$t('msgbox.manage_libraries.reorder')"
               />
             </div>
           </div>
         </div>
       </VueDraggable>
+    </div>
+
+    <div v-if="selectedLibrary" class="mt-2 shrink-0 rounded-box border border-base-content/10 bg-base-100/20 px-3 py-2">
+      <div class="flex items-center justify-between gap-3">
+        <div class="text-xs uppercase tracking-wide text-base-content/40">
+          {{ $t('msgbox.manage_libraries.metadata_storage') }}
+        </div>
+        <div v-if="selectedLibraryInfo" class="text-[11px] text-base-content/40">
+          {{ selectedLibraryInfo.usesDefaultStorage
+            ? $t('msgbox.manage_libraries.default_storage_badge')
+            : $t('msgbox.manage_libraries.custom_storage_badge') }}
+        </div>
+      </div>
+
+      <div class="mt-2 text-xs text-base-content/60">
+        <div class="font-medium text-base-content/80">
+          {{ $t('msgbox.manage_libraries.storage_folder') }}
+        </div>
+        <div class="break-all">
+          {{ selectedLibraryInfo?.storageDir || '—' }}
+        </div>
+      </div>
+
+      <div class="mt-2 grid grid-cols-1 gap-2 text-xs text-base-content/60">
+        <div>
+          <div class="font-medium text-base-content/80">
+            {{ $t('msgbox.manage_libraries.library_file_path') }}
+          </div>
+          <div class="break-all">
+            {{ selectedLibraryInfo?.dbFilePath || '—' }}
+          </div>
+        </div>
+        <div>
+          <div class="font-medium text-base-content/80">
+            {{ $t('msgbox.manage_libraries.storage_status') }}
+          </div>
+          <div :class="selectedLibraryInfo?.storageAvailable ? 'text-success' : 'text-warning'">
+            {{ selectedLibraryInfo?.storageAvailable
+              ? $t('msgbox.manage_libraries.storage_available')
+              : $t('msgbox.manage_libraries.storage_unavailable') }}
+          </div>
+          <div
+            v-if="selectedLibraryRequiresReconnect"
+            class="mt-1 text-warning"
+          >
+            {{ $t('msgbox.manage_libraries.storage_reconnect_hint') }}
+          </div>
+        </div>
+      </div>
+
+      <div class="mt-3 flex flex-wrap items-center gap-2">
+        <button
+          class="px-3 py-1 rounded-box text-sm transition-colors border border-base-content/10"
+          :class="canChangeSelectedStorage ? 'text-base-content/80 hover:bg-base-100/40 cursor-pointer' : 'text-base-content/30 cursor-default'"
+          :disabled="!canChangeSelectedStorage"
+          @click="chooseStorageFolder"
+        >
+          {{ $t('msgbox.manage_libraries.choose_folder') }}
+        </button>
+        <button
+          class="px-3 py-1 rounded-box text-sm transition-colors border border-base-content/10"
+          :class="canResetSelectedStorage ? 'text-base-content/80 hover:bg-base-100/40 cursor-pointer' : 'text-base-content/30 cursor-default'"
+          :disabled="!canResetSelectedStorage"
+          @click="resetStorageFolder"
+        >
+          {{ $t('msgbox.manage_libraries.use_default_storage') }}
+        </button>
+      </div>
+
+      <div v-if="isMovingStorage" class="mt-3">
+        <div class="flex items-center justify-between text-xs text-base-content/50">
+          <span>{{ storageMoveProgress.message || $t('msgbox.manage_libraries.moving_storage') }}</span>
+          <span>{{ storageMoveProgress.percent }}%</span>
+        </div>
+        <ProgressBar :percent="storageMoveProgress.percent" />
+        <div class="mt-2 flex justify-end">
+          <button
+            class="px-3 py-1 rounded-box text-sm transition-colors border border-base-content/10"
+            :class="canCancelStorageMove ? 'text-base-content/80 hover:bg-base-100/40 cursor-pointer' : 'text-base-content/30 cursor-default'"
+            :disabled="!canCancelStorageMove"
+            @click="cancelStorageMove"
+          >
+            {{ $t('msgbox.cancel') }}
+          </button>
+        </div>
+      </div>
     </div>
 
     <!-- button area -->
@@ -117,11 +203,11 @@
         <button
           v-if="!showAddInput" 
           class="inline-flex h-8 items-center gap-2 px-3 py-2 rounded-box border border-base-content/10 text-sm transition-colors"
-          :class="isMaxLibraryReached || isRenaming
+          :class="isMaxLibraryReached || isRenaming || isMovingStorage
             ? 'text-base-content/30 cursor-default'
             : 'text-base-content/70 hover:bg-base-100/30 hover:text-base-content cursor-pointer'"
           :title="isMaxLibraryReached ? $t('msgbox.manage_libraries.max_limit_reached') : $t('msgbox.manage_libraries.add_new')"
-          :disabled="isMaxLibraryReached || isRenaming"
+          :disabled="isMaxLibraryReached || isRenaming || isMovingStorage"
           @click="showAddInput = true"
         >
           <IconAdd class="w-5 h-5" />
@@ -136,22 +222,22 @@
               class="input input-sm flex-1 min-w-0"
               maxlength="32"
               :placeholder="$t('msgbox.manage_libraries.placeholder')"
-              :disabled="isAddingLibrary"
+              :disabled="isAddingLibrary || isMovingStorage"
               @keydown.enter="doAddLibrary"
               @keydown.esc.stop="cancelAddLibrary"
             />
             <button
               class="px-3 py-1 rounded-box text-sm transition-colors shrink-0"
-              :class="isAddingLibrary ? 'text-base-content/30 cursor-default' : 'text-base-content/70 hover:bg-base-100/30 hover:text-base-content cursor-pointer'"
-              :disabled="isAddingLibrary"
+              :class="isAddingLibrary || isMovingStorage ? 'text-base-content/30 cursor-default' : 'text-base-content/70 hover:bg-base-100/30 hover:text-base-content cursor-pointer'"
+              :disabled="isAddingLibrary || isMovingStorage"
               @click="cancelAddLibrary"
             >
               {{ $t('msgbox.cancel') }}
             </button>
             <button
               class="px-3 py-1 rounded-box text-sm transition-colors shrink-0"
-              :class="canSubmitNewLibrary ? 'bg-primary text-primary-content hover:opacity-90 cursor-pointer' : 'bg-base-100/40 text-base-content/30 cursor-default'"
-              :disabled="!canSubmitNewLibrary"
+              :class="canSubmitNewLibrary && !isMovingStorage ? 'bg-primary text-primary-content hover:opacity-90 cursor-pointer' : 'bg-base-100/40 text-base-content/30 cursor-default'"
+              :disabled="!canSubmitNewLibrary || isMovingStorage"
               @click="doAddLibrary"
             >
               {{ isAddingLibrary ? $t('tooltip.loading') : $t('msgbox.manage_libraries.add') }}
@@ -165,6 +251,7 @@
 
       <button
         class="px-4 py-1 rounded-box text-base-content/70 hover:bg-primary hover:text-base-100 cursor-pointer shrink-0"
+        :class="{ 'opacity-40 cursor-default pointer-events-none': isMovingStorage }"
         @click="clickOk"
       >
         {{ $t('msgbox.ok') }}
@@ -202,10 +289,12 @@ import {
   getLibraryInfo,
   switchLibrary,
 } from '@/common/api';
-import { formatTimestamp, isValidFileName, formatFileSize } from '@/common/utils';
+import { formatTimestamp, isValidFileName, formatFileSize, openFolderDialog } from '@/common/utils';
+import { requiresConnectedMetadataStorage } from '@/common/libraryMove';
 import ModalDialog from '@/components/ModalDialog.vue';
 import TButton from '@/components/TButton.vue';
-import MessageBox from '@/components/MessageBox.vue'; // Need to import or ensure it is available
+import MessageBox from '@/components/MessageBox.vue';
+import ProgressBar from '@/components/ProgressBar.vue';
 import {
   IconDragHandle,
   IconEdit,
@@ -218,6 +307,9 @@ import {
 // Props are less relevant now but kept for compatibility logic if needed
 const props = defineProps({
   isNewLibrary: { type: Boolean, default: false },
+  moveStorage: { type: Function, default: null },
+  cancelMoveStorage: { type: Function, default: null },
+  moveStorageState: { type: Object, default: () => null },
 });
 
 const emit = defineEmits(['ok', 'cancel']);
@@ -241,6 +333,49 @@ let statsLoadToken = 0;
 
 const isRenaming = computed(() => !!editingId.value);
 const canSubmitNewLibrary = computed(() => !!newLibraryName.value.trim() && !inputErrorMessage.value && !isAddingLibrary.value);
+const selectedLibrary = computed(() => libraries.value.find(lib => lib.id === selectedLibraryId.value) || null);
+const selectedLibraryInfo = computed(() => selectedLibraryId.value ? libraryStats.value[selectedLibraryId.value] || null : null);
+const isMovingStorage = computed(() => Boolean((props.moveStorageState as any)?.active));
+const storageMoveProgress = computed(() => (props.moveStorageState as any) || {
+  phase: '',
+  percent: 0,
+  bytesCopied: 0,
+  totalBytes: 0,
+  message: '',
+  cancellable: false,
+  cancelRequested: false,
+  status: 'idle',
+});
+const selectedLibraryRequiresReconnect = computed(() =>
+  requiresConnectedMetadataStorage(selectedLibraryInfo.value)
+);
+const canChangeSelectedStorage = computed(() =>
+  !!selectedLibrary.value &&
+  !isMovingStorage.value &&
+  !showAddInput.value &&
+  !isRenaming.value &&
+  !selectedLibraryRequiresReconnect.value
+);
+const canResetSelectedStorage = computed(() =>
+  canChangeSelectedStorage.value &&
+  !!selectedLibraryInfo.value &&
+  !selectedLibraryInfo.value.usesDefaultStorage
+);
+const canCancelStorageMove = computed(() =>
+  isMovingStorage.value &&
+  Boolean(storageMoveProgress.value?.cancellable) &&
+  !Boolean(storageMoveProgress.value?.cancelRequested)
+);
+
+const isDeleteBlockedForLibrary = (libraryId: string) =>
+  requiresConnectedMetadataStorage(libraryStats.value[libraryId]);
+
+const isDeleteDisabled = (lib: any) =>
+  lib.id === 'default' ||
+  showAddInput.value ||
+  isRenaming.value ||
+  isMovingStorage.value ||
+  isDeleteBlockedForLibrary(lib.id);
 
 const isMaxLibraryReached = computed(() => {
   const max = (config as any).main?.maxLibraryCount || 10;
@@ -375,6 +510,28 @@ const loadLibraryStats = async (libs: any[]) => {
   });
 };
 
+const refreshLibraryInfo = async (libraryId: string) => {
+  libraryStatsLoading.value = {
+    ...libraryStatsLoading.value,
+    [libraryId]: true,
+  };
+
+  try {
+    const info = await getLibraryInfo(libraryId);
+    if (info) {
+      libraryStats.value = {
+        ...libraryStats.value,
+        [libraryId]: info,
+      };
+    }
+  } finally {
+    libraryStatsLoading.value = {
+      ...libraryStatsLoading.value,
+      [libraryId]: false,
+    };
+  }
+};
+
 // --- Actions ---
 
 const startRename = (lib: any) => {
@@ -445,7 +602,7 @@ const doAddLibrary = async () => {
 };
 
 const cancelAddLibrary = () => {
-  if (isAddingLibrary.value) return;
+  if (isAddingLibrary.value || isMovingStorage.value) return;
   showAddInput.value = false;
   newLibraryName.value = '';
   inputErrorMessage.value = '';
@@ -460,7 +617,7 @@ const focusLibrary = async (libraryId: string) => {
 };
 
 const selectLibrary = async (lib: any) => {
-  if (showAddInput.value || isRenaming.value || editingId.value === lib.id) return;
+  if (showAddInput.value || isRenaming.value || isMovingStorage.value || editingId.value === lib.id) return;
   selectedLibraryId.value = lib.id;
   await focusLibrary(lib.id);
 };
@@ -477,12 +634,13 @@ const toggleVisibility = async (lib: any) => {
 };
 
 const confirmDelete = (lib: any) => {
+  if (isDeleteDisabled(lib)) return;
   libraryToDelete.value = lib;
   showDeleteConfirm.value = true;
 };
 
 const doDeleteLibrary = async () => {
-  if (!libraryToDelete.value) return;
+  if (!libraryToDelete.value || isMovingStorage.value || isDeleteBlockedForLibrary(libraryToDelete.value.id)) return;
   try {
     await removeLibrary(libraryToDelete.value.id);
     showDeleteConfirm.value = false;
@@ -495,13 +653,16 @@ const doDeleteLibrary = async () => {
 };
 
 const clickOk = async () => {
+  if (isMovingStorage.value) return;
   if (selectedLibraryId.value && selectedLibraryId.value !== currentLibraryId.value) {
     try {
+      inputErrorMessage.value = '';
       await switchLibrary(selectedLibraryId.value);
       emit('ok', { type: 'switch', id: selectedLibraryId.value });
       return;
-    } catch (error) {
+    } catch (error: any) {
       console.error(error);
+      inputErrorMessage.value = error?.message || error?.toString?.() || String(error);
       return;
     }
   }
@@ -509,12 +670,54 @@ const clickOk = async () => {
 };
 
 const clickCancel = () => {
+  if (isMovingStorage.value) return;
   emit('cancel');
+};
+
+const moveSelectedLibraryStorage = async (storageDir: string | null) => {
+  if (!selectedLibrary.value || !props.moveStorage || isMovingStorage.value) return;
+
+  try {
+    inputErrorMessage.value = '';
+    await props.moveStorage(selectedLibrary.value.id, storageDir);
+    await loadLibraries();
+    await refreshLibraryInfo(selectedLibrary.value.id);
+    emit('ok', { type: 'move-storage', id: selectedLibrary.value.id });
+  } catch (error: any) {
+    const message = error?.message || error?.toString?.() || String(error);
+    if (message.includes('Library storage move cancelled.')) {
+      inputErrorMessage.value = '';
+      return;
+    }
+    inputErrorMessage.value = message;
+  }
+};
+
+const cancelStorageMove = async () => {
+  if (!canCancelStorageMove.value || !props.cancelMoveStorage) return;
+  try {
+    await props.cancelMoveStorage();
+  } catch (error) {
+    console.error(error);
+  }
+};
+
+const chooseStorageFolder = async () => {
+  if (!canChangeSelectedStorage.value) return;
+  const selected = await openFolderDialog();
+  if (!selected || Array.isArray(selected)) return;
+  await moveSelectedLibraryStorage(String(selected));
+};
+
+const resetStorageFolder = async () => {
+  if (!canResetSelectedStorage.value) return;
+  await moveSelectedLibraryStorage(null);
 };
 
 // --- Drag and Drop ---
 
 const onDragEnd = async () => {
+  if (isMovingStorage.value) return;
   // Persist order
   const ids = libraries.value.map(l => l.id);
   try {

--- a/src-vite/src/locales/de.json
+++ b/src-vite/src/locales/de.json
@@ -440,7 +440,19 @@
       "calculating_stats": "Bibliotheksgroesse wird berechnet...",
       "library_file_path": "Dateipfad",
       "library_file_size": "Dateigröße",
-      "created_at": "Erstellt am"
+      "created_at": "Erstellt am",
+      "metadata_storage": "Metadata storage",
+      "default_storage_badge": "Default storage",
+      "custom_storage_badge": "Custom storage",
+      "storage_folder": "Storage folder",
+      "storage_status": "Storage status",
+      "storage_available": "Available",
+      "storage_unavailable": "Disconnected",
+      "storage_reconnect_hint": "Reconnect the selected storage before moving this library.",
+      "choose_folder": "Choose folder...",
+      "use_default_storage": "Use default storage",
+      "moving_storage": "Moving library metadata...",
+      "moving_to_default_storage": "Moving library metadata to default storage..."
     },
     "remove_library": {
       "title": "Bibliothek entfernen",

--- a/src-vite/src/locales/en.json
+++ b/src-vite/src/locales/en.json
@@ -440,7 +440,19 @@
       "calculating_stats": "Calculating library size...",
       "library_file_path": "Library file path",
       "library_file_size": "Library file size",
-      "created_at": "Created at"
+      "created_at": "Created at",
+      "metadata_storage": "Metadata storage",
+      "default_storage_badge": "Default storage",
+      "custom_storage_badge": "Custom storage",
+      "storage_folder": "Storage folder",
+      "storage_status": "Storage status",
+      "storage_available": "Available",
+      "storage_unavailable": "Disconnected",
+      "storage_reconnect_hint": "Reconnect the selected storage before moving this library.",
+      "choose_folder": "Choose folder...",
+      "use_default_storage": "Use default storage",
+      "moving_storage": "Moving library metadata...",
+      "moving_to_default_storage": "Moving library metadata to default storage..."
     },
     "remove_library": {
       "title": "Remove library",

--- a/src-vite/src/locales/es.json
+++ b/src-vite/src/locales/es.json
@@ -440,7 +440,19 @@
       "calculating_stats": "Calculando el tamano de la biblioteca...",
       "library_file_path": "Ruta archivo",
       "library_file_size": "Tamaño archivo",
-      "created_at": "Creado el"
+      "created_at": "Creado el",
+      "metadata_storage": "Metadata storage",
+      "default_storage_badge": "Default storage",
+      "custom_storage_badge": "Custom storage",
+      "storage_folder": "Storage folder",
+      "storage_status": "Storage status",
+      "storage_available": "Available",
+      "storage_unavailable": "Disconnected",
+      "storage_reconnect_hint": "Reconnect the selected storage before moving this library.",
+      "choose_folder": "Choose folder...",
+      "use_default_storage": "Use default storage",
+      "moving_storage": "Moving library metadata...",
+      "moving_to_default_storage": "Moving library metadata to default storage..."
     },
     "remove_library": {
       "title": "Eliminar biblioteca",

--- a/src-vite/src/locales/fr.json
+++ b/src-vite/src/locales/fr.json
@@ -440,7 +440,19 @@
       "calculating_stats": "Calcul de la taille de la bibliothèque...",
       "library_file_path": "Chemin fichier",
       "library_file_size": "Taille fichier",
-      "created_at": "Créé le"
+      "created_at": "Créé le",
+      "metadata_storage": "Metadata storage",
+      "default_storage_badge": "Default storage",
+      "custom_storage_badge": "Custom storage",
+      "storage_folder": "Storage folder",
+      "storage_status": "Storage status",
+      "storage_available": "Available",
+      "storage_unavailable": "Disconnected",
+      "storage_reconnect_hint": "Reconnect the selected storage before moving this library.",
+      "choose_folder": "Choose folder...",
+      "use_default_storage": "Use default storage",
+      "moving_storage": "Moving library metadata...",
+      "moving_to_default_storage": "Moving library metadata to default storage..."
     },
     "remove_library": {
       "title": "Supprimer bibliothèque",

--- a/src-vite/src/locales/ja.json
+++ b/src-vite/src/locales/ja.json
@@ -440,7 +440,19 @@
       "calculating_stats": "ライブラリサイズを計算中...",
       "library_file_path": "ファイルパス",
       "library_file_size": "ファイルサイズ",
-      "created_at": "作成日時"
+      "created_at": "作成日時",
+      "metadata_storage": "Metadata storage",
+      "default_storage_badge": "Default storage",
+      "custom_storage_badge": "Custom storage",
+      "storage_folder": "Storage folder",
+      "storage_status": "Storage status",
+      "storage_available": "Available",
+      "storage_unavailable": "Disconnected",
+      "storage_reconnect_hint": "Reconnect the selected storage before moving this library.",
+      "choose_folder": "Choose folder...",
+      "use_default_storage": "Use default storage",
+      "moving_storage": "Moving library metadata...",
+      "moving_to_default_storage": "Moving library metadata to default storage..."
     },
     "remove_library": {
       "title": "ライブラリを削除",

--- a/src-vite/src/locales/ko.json
+++ b/src-vite/src/locales/ko.json
@@ -440,7 +440,19 @@
       "calculating_stats": "라이브러리 크기 계산 중...",
       "library_file_path": "파일 경로",
       "library_file_size": "파일 크기",
-      "created_at": "생성일"
+      "created_at": "생성일",
+      "metadata_storage": "메타데이터 저장소",
+      "default_storage_badge": "기본 저장소",
+      "custom_storage_badge": "사용자 지정 저장소",
+      "storage_folder": "저장 폴더",
+      "storage_status": "저장소 상태",
+      "storage_available": "사용 가능",
+      "storage_unavailable": "연결 끊김",
+      "storage_reconnect_hint": "이 라이브러리를 이동하려면 먼저 선택한 저장소를 다시 연결하세요.",
+      "choose_folder": "폴더 선택...",
+      "use_default_storage": "기본 저장소 사용",
+      "moving_storage": "라이브러리 메타데이터 이동 중...",
+      "moving_to_default_storage": "라이브러리 메타데이터를 기본 저장소로 이동 중..."
     },
     "remove_library": {
       "title": "라이브러리 제거",

--- a/src-vite/src/locales/pt.json
+++ b/src-vite/src/locales/pt.json
@@ -440,7 +440,19 @@
       "calculating_stats": "Calculando o tamanho da biblioteca...",
       "library_file_path": "Caminho do arquivo",
       "library_file_size": "Tamanho do arquivo",
-      "created_at": "Criado em"
+      "created_at": "Criado em",
+      "metadata_storage": "Metadata storage",
+      "default_storage_badge": "Default storage",
+      "custom_storage_badge": "Custom storage",
+      "storage_folder": "Storage folder",
+      "storage_status": "Storage status",
+      "storage_available": "Available",
+      "storage_unavailable": "Disconnected",
+      "storage_reconnect_hint": "Reconnect the selected storage before moving this library.",
+      "choose_folder": "Choose folder...",
+      "use_default_storage": "Use default storage",
+      "moving_storage": "Moving library metadata...",
+      "moving_to_default_storage": "Moving library metadata to default storage..."
     },
     "remove_library": {
       "title": "Remover biblioteca",

--- a/src-vite/src/locales/ru.json
+++ b/src-vite/src/locales/ru.json
@@ -440,7 +440,19 @@
       "calculating_stats": "Вычисляется размер библиотеки...",
       "library_file_path": "Путь к файлу",
       "library_file_size": "Размер файла",
-      "created_at": "Создано"
+      "created_at": "Создано",
+      "metadata_storage": "Metadata storage",
+      "default_storage_badge": "Default storage",
+      "custom_storage_badge": "Custom storage",
+      "storage_folder": "Storage folder",
+      "storage_status": "Storage status",
+      "storage_available": "Available",
+      "storage_unavailable": "Disconnected",
+      "storage_reconnect_hint": "Reconnect the selected storage before moving this library.",
+      "choose_folder": "Choose folder...",
+      "use_default_storage": "Use default storage",
+      "moving_storage": "Moving library metadata...",
+      "moving_to_default_storage": "Moving library metadata to default storage..."
     },
     "remove_library": {
       "title": "Удалить библиотеку",

--- a/src-vite/src/locales/zh.json
+++ b/src-vite/src/locales/zh.json
@@ -440,7 +440,19 @@
       "calculating_stats": "正在计算库大小...",
       "library_file_path": "库文件路径",
       "library_file_size": "库文件大小",
-      "created_at": "创建时间"
+      "created_at": "创建时间",
+      "metadata_storage": "Metadata storage",
+      "default_storage_badge": "Default storage",
+      "custom_storage_badge": "Custom storage",
+      "storage_folder": "Storage folder",
+      "storage_status": "Storage status",
+      "storage_available": "Available",
+      "storage_unavailable": "Disconnected",
+      "storage_reconnect_hint": "Reconnect the selected storage before moving this library.",
+      "choose_folder": "Choose folder...",
+      "use_default_storage": "Use default storage",
+      "moving_storage": "Moving library metadata...",
+      "moving_to_default_storage": "Moving library metadata to default storage..."
     },
     "remove_library": {
       "title": "移除库",

--- a/src-vite/src/test/setup.js
+++ b/src-vite/src/test/setup.js
@@ -1,0 +1,33 @@
+class ResizeObserverMock {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+if (!globalThis.ResizeObserver) {
+  globalThis.ResizeObserver = ResizeObserverMock;
+}
+
+if (!globalThis.matchMedia) {
+  globalThis.matchMedia = () => ({
+    matches: false,
+    media: '',
+    onchange: null,
+    addListener() {},
+    removeListener() {},
+    addEventListener() {},
+    removeEventListener() {},
+    dispatchEvent() { return false; },
+  });
+}
+
+if (!globalThis.requestAnimationFrame) {
+  globalThis.requestAnimationFrame = (callback) => {
+    callback(0);
+    return 0;
+  };
+}
+
+if (!globalThis.cancelAnimationFrame) {
+  globalThis.cancelAnimationFrame = () => {};
+}

--- a/src-vite/src/views/Home.vue
+++ b/src-vite/src/views/Home.vue
@@ -10,6 +10,27 @@
       </div>
     </transition>
 
+    <transition name="fade">
+      <div
+        v-if="libraryMoveState.active"
+        class="absolute inset-0 z-[550] bg-base-300/50 backdrop-blur-sm flex items-center justify-center pointer-events-auto"
+      >
+        <div class="rounded-box border border-base-content/10 bg-base-200/80 px-4 py-3 min-w-72 shadow-lg">
+          <div class="flex items-center gap-3">
+            <span class="loading loading-spinner loading-md text-primary"></span>
+            <div class="min-w-0">
+              <div class="text-sm text-base-content/80 truncate">
+                {{ libraryMoveState.message }}
+              </div>
+              <div class="mt-1 text-xs text-base-content/50">
+                {{ libraryMoveState.percent }}%
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </transition>
+
     <!-- Title Bar -->
     <TitleBar v-if="isWin" titlebar="Lap" viewName="Home" :icon="iconLogo"/>
 
@@ -127,14 +148,14 @@
         @mouseup="stopDraggingSplitter"
       ></div>
        
-      <!-- content area -->
+        <!-- content area -->
       <div 
         :class="[
           'flex-1 flex relative',
           isWin ? 'rounded-tl-box' : '',
         ]"
       >
-        <Content :titlebar="buttons[config.main.sidebarIndex].text"/>
+        <Content ref="contentRef" :titlebar="buttons[config.main.sidebarIndex].text"/>
       </div>
     </div>
 
@@ -146,6 +167,9 @@
     <!-- Manage Libraries Dialog -->
     <ManageLibraries
       v-if="showManageLibraries"
+      :move-storage="handleMoveLibraryStorage"
+      :cancel-move-storage="handleCancelLibraryMove"
+      :move-storage-state="libraryMoveState"
       @ok="onManageLibrariesOk"
       @cancel="showManageLibraries = false"
     />
@@ -162,10 +186,27 @@ import { emit, listen } from '@tauri-apps/api/event';
 import { WebviewWindow } from '@tauri-apps/api/webviewWindow';
 import { getName } from '@tauri-apps/api/app';
 import { config, libConfig } from '@/common/config';
+import {
+  LIBRARY_MOVE_CANCELLED_ERROR,
+  pickLibraryMoveError,
+  shouldResumeFace,
+  sleep,
+  waitForFaceIndexIdle,
+} from '@/common/libraryMove';
 import { useAppUpdater } from '@/common/updater';
 import { useUIStore } from '@/stores/uiStore';
 import { isWin, isMac, SCALE_VALUES } from '@/common/utils';
-import { getAppConfig, switchLibrary, cancelIndexing, cancelFaceIndex } from '@/common/api';
+import {
+  getAppConfig,
+  switchLibrary,
+  moveLibraryStorage,
+  cancelLibraryStorageMove,
+  cancelIndexing,
+  cancelFaceIndex,
+  isFaceIndexing,
+  indexFaces,
+  listenLibraryStorageMoveProgress,
+} from '@/common/api';
 
 // vue components
 import Library from '@/components/Library.vue';
@@ -212,6 +253,7 @@ const uiStore = useUIStore();
 
 // Panel component ref
 const panelRef = ref<any>(null);
+const contentRef = ref<any>(null);
 const showPanel = ref(true);
 
 // Library state
@@ -227,13 +269,71 @@ interface AppConfig {
   libraries: Library[];
 }
 
+interface LibraryMoveState {
+  active: boolean;
+  libraryId: string;
+  phase: string;
+  percent: number;
+  bytesCopied: number;
+  totalBytes: number;
+  message: string;
+  cancellable: boolean;
+  cancelRequested: boolean;
+  status: string;
+}
+
+interface FaceMoveState {
+  wasRunning: boolean;
+  stoppedCleanly: boolean;
+}
+
 const appConfig = ref<AppConfig | null>(null);
+
+function getCurrentFaceClusterEpsilon() {
+  const face = config.settings.face;
+  const thresholdIndex = face?.clusterThresholdIndex ?? 2;
+  const thresholds = config.faceClusterThresholds ?? [0.35, 0.45, 0.55, 0.65];
+  return thresholds[thresholdIndex] ?? 0.55;
+}
+
+function resetLibraryMoveState() {
+  libraryMoveState.value = {
+    active: false,
+    libraryId: '',
+    phase: '',
+    percent: 0,
+    bytesCopied: 0,
+    totalBytes: 0,
+    message: '',
+    cancellable: false,
+    cancelRequested: false,
+    status: 'idle',
+  };
+}
+
+function assertLibraryMoveNotCancelled() {
+  if (libraryMoveState.value.cancelRequested) {
+    throw new Error(LIBRARY_MOVE_CANCELLED_ERROR);
+  }
+}
 const currentLibrary = computed(() => 
   appConfig.value?.libraries.find(l => l.id === appConfig.value?.current_library_id) || null
 );
 
 // Manage Libraries dialog state
 const showManageLibraries = ref(false);
+const libraryMoveState = ref<LibraryMoveState>({
+  active: false,
+  libraryId: '',
+  phase: '',
+  percent: 0,
+  bytesCopied: 0,
+  totalBytes: 0,
+  message: '',
+  cancellable: false,
+  cancelRequested: false,
+  status: 'idle',
+});
 
 /// Splitter for resizing the left pane
 const isDraggingSplitter = ref(false);
@@ -243,6 +343,7 @@ const showDebugBadge = import.meta.env.DEV;
 const toolTipRef = ref<InstanceType<typeof ToolTip> | null>(null);
 let unlistenOpenPreferences: (() => void) | null = null;
 let unlistenOpenAbout: (() => void) | null = null;
+let unlistenStorageMoveProgress: (() => void) | null = null;
 const {
   updateAvailable,
   isCheckingUpdate,
@@ -320,6 +421,23 @@ onMounted(async () => {
   unlistenOpenAbout = await listen('app-open-about', () => {
     void clickSettings(5);
   });
+  unlistenStorageMoveProgress = await listenLibraryStorageMoveProgress((event: any) => {
+    const payload = event?.payload || {};
+    if (!libraryMoveState.value.active) return;
+    if (String(payload.libraryId || '') !== libraryMoveState.value.libraryId) return;
+
+    libraryMoveState.value = {
+      ...libraryMoveState.value,
+      phase: String(payload.phase || libraryMoveState.value.phase || ''),
+      percent: Number(payload.percent || 0),
+      bytesCopied: Number(payload.bytesCopied || 0),
+      totalBytes: Number(payload.totalBytes || 0),
+      message: String(payload.message || libraryMoveState.value.message || ''),
+      cancellable: Boolean(payload.cancellable),
+      cancelRequested: Boolean(payload.cancelRequested),
+      status: String(payload.status || libraryMoveState.value.status || 'running'),
+    };
+  });
 
   appConfig.value = await getAppConfig();
   
@@ -338,6 +456,8 @@ onBeforeUnmount(() => {
   unlistenOpenPreferences = null;
   unlistenOpenAbout?.();
   unlistenOpenAbout = null;
+  unlistenStorageMoveProgress?.();
+  unlistenStorageMoveProgress = null;
 });
 
 const doSwitchLibrary = async (libraryId: string) => {
@@ -368,6 +488,134 @@ const doSwitchLibrary = async (libraryId: string) => {
     libConfig._initialized = true;
     isSwitchingLibrary.value = false;
     console.error('Failed to switch library:', error);
+  }
+};
+
+const handleMoveLibraryStorage = async (libraryId: string, storageDir: string | null) => {
+  const shouldQuiesceWrites = Boolean(appConfig.value?.current_library_id);
+  const previousInitialized = Boolean(libConfig._initialized);
+  let moveSnapshot: any = null;
+  let moveInfo: any = null;
+  let primaryError: any = null;
+  let cleanupError: any = null;
+  const faceMoveState: FaceMoveState = {
+    wasRunning: false,
+    stoppedCleanly: false,
+  };
+
+  try {
+    libraryMoveState.value = {
+      active: true,
+      libraryId,
+      phase: 'quiescing',
+      percent: 0,
+      bytesCopied: 0,
+      totalBytes: 0,
+      message: storageDir
+        ? localeMsg.value.msgbox.manage_libraries.moving_storage
+        : localeMsg.value.msgbox.manage_libraries.moving_to_default_storage,
+      cancellable: true,
+      cancelRequested: false,
+      status: 'running',
+    };
+
+    if (shouldQuiesceWrites) {
+      await libConfig.save();
+      libConfig._initialized = false;
+
+      if (contentRef.value?.prepareForLibraryStorageMove) {
+        moveSnapshot = await contentRef.value.prepareForLibraryStorageMove();
+      }
+      assertLibraryMoveNotCancelled();
+
+      const faceState = await isFaceIndexing({ strict: true });
+      faceMoveState.wasRunning = Array.isArray(faceState) ? Boolean(faceState[0]) : Boolean(faceState);
+      if (faceMoveState.wasRunning) {
+        await cancelFaceIndex();
+        await waitForFaceIndexIdle(isFaceIndexing);
+        faceMoveState.stoppedCleanly = true;
+      }
+      assertLibraryMoveNotCancelled();
+    }
+
+    assertLibraryMoveNotCancelled();
+    libraryMoveState.value = {
+      ...libraryMoveState.value,
+      phase: 'dispatching',
+      cancellable: false,
+    };
+    moveInfo = await moveLibraryStorage(libraryId, storageDir);
+    appConfig.value = await getAppConfig();
+  } catch (error: any) {
+    if (!moveSnapshot && error?.libraryMoveSnapshot) {
+      moveSnapshot = error.libraryMoveSnapshot;
+    }
+    primaryError = error;
+  } finally {
+    if (shouldQuiesceWrites) {
+      try {
+        if (contentRef.value?.resumeAfterLibraryStorageMove) {
+          await contentRef.value.resumeAfterLibraryStorageMove(moveSnapshot);
+        }
+        if (shouldResumeFace(faceMoveState)) {
+          await indexFaces(getCurrentFaceClusterEpsilon());
+        }
+      } catch (error: any) {
+        cleanupError = cleanupError || error;
+        if (primaryError) {
+          console.error('Failed to resume background work after library storage move error:', error);
+        }
+      } finally {
+        libConfig._initialized = previousInitialized;
+        if (libConfig._initialized) {
+          try {
+            await libConfig.save();
+          } catch (error: any) {
+            cleanupError = cleanupError || error;
+            if (primaryError) {
+              console.error('Failed to persist library config after library storage move error:', error);
+            }
+          }
+        }
+      }
+    }
+
+    resetLibraryMoveState();
+  }
+
+  const finalError = pickLibraryMoveError(primaryError, cleanupError);
+  if (finalError) {
+    throw finalError;
+  }
+
+  return moveInfo;
+};
+
+const handleCancelLibraryMove = async () => {
+  if (!libraryMoveState.value.active || !libraryMoveState.value.libraryId) return;
+  if (libraryMoveState.value.cancelRequested || !libraryMoveState.value.cancellable) return;
+
+  libraryMoveState.value = {
+    ...libraryMoveState.value,
+    cancelRequested: true,
+  };
+
+  if (libraryMoveState.value.phase === 'quiescing') {
+    return;
+  }
+
+  try {
+    await cancelLibraryStorageMove(libraryMoveState.value.libraryId);
+  } catch (error: any) {
+    const message = error?.message || error?.toString?.() || String(error || '');
+    if (message.includes('No active storage move')) {
+      await sleep(100);
+      if (libraryMoveState.value.active && libraryMoveState.value.phase !== 'quiescing') {
+        await cancelLibraryStorageMove(libraryMoveState.value.libraryId);
+      }
+      return;
+    }
+    throw error;
   }
 };
 

--- a/src-vite/vite.config.js
+++ b/src-vite/vite.config.js
@@ -24,5 +24,10 @@ export default defineConfig({
   build: {
     outDir: './dist',
     emptyOutDir: true,
-  }
+  },
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    setupFiles: './src/test/setup.js',
+  },
 });


### PR DESCRIPTION
## Summary
The main goal of this PR is to let users change where a `Library` stores its metadata SQLite database.

The motivating case is moving library metadata off a small internal disk and onto an external drive, while keeping the current default location unchanged for libraries that do not opt into a custom storage folder.

This PR is larger than the UI change suggests because moving a live SQLite-backed library safely touches:
- per-library config and path resolution
- database open/create behavior
- background-job coordination while a move is in progress
- cancellation/progress UX
- disconnected-storage safety and rollback behavior
- automated tests

## What changed
- Added per-library metadata storage directories in app config.
- Added a safe metadata move flow with copy -> verify -> commit, cancellation, and progress events.
- Blocked metadata writes while a move is active and required indexing / dedup / face indexing to quiesce first.
- Added UI to inspect the active metadata storage location, choose a different folder, or revert to the default location.
- Added Rust and frontend tests for the new behavior.

## Suggested review order
Please review this PR with one question in mind first:

**Does this preserve the existing default behavior while making `Library` metadata storage relocatable in a safe way?**

### 1. Backend storage model and move safety
This is the core of the change.

- `src-tauri/src/t_config.rs`
  - storage-dir normalization / effective path resolution / disconnected-storage policy:
    - [L319-L439](https://github.com/kimjj81/lap/blob/feature/library-metadata-storage-move/src-tauri/src/t_config.rs#L319-L439)
  - safe library deletion with quarantine + rollback:
    - [L833-L903](https://github.com/kimjj81/lap/blob/feature/library-metadata-storage-move/src-tauri/src/t_config.rs#L833-L903)
  - `LibraryInfo`, move progress payload, and cancellation state:
    - [L921-L1256](https://github.com/kimjj81/lap/blob/feature/library-metadata-storage-move/src-tauri/src/t_config.rs#L921-L1256)
  - copy / verify / commit move implementation:
    - [L1360-L1660](https://github.com/kimjj81/lap/blob/feature/library-metadata-storage-move/src-tauri/src/t_config.rs#L1360-L1660)
  - Rust tests for the new policy and rollback behavior:
    - [L1784-L2036](https://github.com/kimjj81/lap/blob/feature/library-metadata-storage-move/src-tauri/src/t_config.rs#L1784-L2036)

Review lens:
- Does `storage_dir = null` keep the old behavior intact?
- Are disconnected-storage semantics conservative enough?
- Is the rollback behavior acceptable if deletion or move cleanup fails?

### 2. Tauri command surface and DB lifecycle
- `src-tauri/src/t_cmds.rs`
  - new move commands, indexing activity tracking, and backend write gating:
    - [L25-L145](https://github.com/kimjj81/lap/blob/feature/library-metadata-storage-move/src-tauri/src/t_cmds.rs#L25-L145)
    - [L156-L160](https://github.com/kimjj81/lap/blob/feature/library-metadata-storage-move/src-tauri/src/t_cmds.rs#L156-L160)
    - [L985-L1044](https://github.com/kimjj81/lap/blob/feature/library-metadata-storage-move/src-tauri/src/t_cmds.rs#L985-L1044)
- `src-tauri/src/t_sqlite.rs`
  - DB open/create now uses the library-specific path and persists `metadata_initialized`:
    - [L3277-L3317](https://github.com/kimjj81/lap/blob/feature/library-metadata-storage-move/src-tauri/src/t_sqlite.rs#L3277-L3317)
- `src-tauri/src/main.rs`
  - state wiring and command registration:
    - [L63-L75](https://github.com/kimjj81/lap/blob/feature/library-metadata-storage-move/src-tauri/src/main.rs#L63-L75)
    - [L144-L170](https://github.com/kimjj81/lap/blob/feature/library-metadata-storage-move/src-tauri/src/main.rs#L144-L170)

Review lens:
- Are the write gates in the right places during an active storage move?
- Is the DB lifecycle still compatible with startup and library switching?

### 3. Frontend move UX and orchestration
- `src-vite/src/components/ManageLibraries.vue`
  - storage location UI, action gating, and move controls:
    - [L113-L197](https://github.com/kimjj81/lap/blob/feature/library-metadata-storage-move/src-vite/src/components/ManageLibraries.vue#L113-L197)
    - [L336-L378](https://github.com/kimjj81/lap/blob/feature/library-metadata-storage-move/src-vite/src/components/ManageLibraries.vue#L336-L378)
    - [L677-L715](https://github.com/kimjj81/lap/blob/feature/library-metadata-storage-move/src-vite/src/components/ManageLibraries.vue#L677-L715)
- `src-vite/src/views/Home.vue`
  - move orchestration, quiesce/cancel/resume, and blocking overlay:
    - [L13-L31](https://github.com/kimjj81/lap/blob/feature/library-metadata-storage-move/src-vite/src/views/Home.vue#L13-L31)
    - [L494-L610](https://github.com/kimjj81/lap/blob/feature/library-metadata-storage-move/src-vite/src/views/Home.vue#L494-L610)
- `src-vite/src/components/Content.vue`
  - indexing/dedup quiesce snapshot and resume:
    - [L2194-L2240](https://github.com/kimjj81/lap/blob/feature/library-metadata-storage-move/src-vite/src/components/Content.vue#L2194-L2240)
- `src-vite/src/common/api.js`
  - new move/cancel APIs and strict status polling for quiesce:
    - [L90-L120](https://github.com/kimjj81/lap/blob/feature/library-metadata-storage-move/src-vite/src/common/api.js#L90-L120)
    - [L1166-L1309](https://github.com/kimjj81/lap/blob/feature/library-metadata-storage-move/src-vite/src/common/api.js#L1166-L1309)
- `src-vite/src/common/libraryMove.js`
  - shared move helpers and resume predicates:
    - [L1-L133](https://github.com/kimjj81/lap/blob/feature/library-metadata-storage-move/src-vite/src/common/libraryMove.js#L1-L133)

Review lens:
- Is the UX understandable for a potentially long-running metadata move?
- Are the quiesce / cancel / resume semantics clear enough?
- Is the disconnected-storage behavior acceptable from a user perspective?

### 4. Tests and supporting changes
- `src-vite/src/common/libraryMove.test.js`
  - move helper failure and resume tests:
    - [L1-L122](https://github.com/kimjj81/lap/blob/feature/library-metadata-storage-move/src-vite/src/common/libraryMove.test.js#L1-L122)
- `src-vite/src/components/ManageLibraries.test.js`
  - disconnected-storage delete guard:
    - [L75-L123](https://github.com/kimjj81/lap/blob/feature/library-metadata-storage-move/src-vite/src/components/ManageLibraries.test.js#L75-L123)
- `src-vite/src/test/setup.js`
  - jsdom test shims:
    - [L1-L33](https://github.com/kimjj81/lap/blob/feature/library-metadata-storage-move/src-vite/src/test/setup.js#L1-L33)
- `src-vite/package.json` / `src-vite/vite.config.js`
  - Vitest wiring:
    - [package.json#L6-L12](https://github.com/kimjj81/lap/blob/feature/library-metadata-storage-move/src-vite/package.json#L6-L12)
    - [vite.config.js#L28-L32](https://github.com/kimjj81/lap/blob/feature/library-metadata-storage-move/src-vite/vite.config.js#L28-L32)
- `src-vite/src/locales/*.json`
  - only adds strings for the new storage UI; low review value.
- `src-vite/pnpm-lock.yaml`
  - lockfile update for new frontend test dependencies.
- `src-tauri/src/t_utils.rs` / `src-tauri/src/t_video.rs`
  - incidental non-functional cleanup, not central to the feature:
    - [t_utils.rs#L15-L24](https://github.com/kimjj81/lap/blob/feature/library-metadata-storage-move/src-tauri/src/t_utils.rs#L15-L24)
    - [t_video.rs#L24-L140](https://github.com/kimjj81/lap/blob/feature/library-metadata-storage-move/src-tauri/src/t_video.rs#L24-L140)

## Verification
I ran:
- `cargo test`
- `pnpm --dir src-vite test --run`
- `pnpm --dir src-vite build`

If this is still too much in one review pass, I would recommend reviewing sections 1 and 2 first, because they define the data-safety model for the whole feature.