### PR TITLE
I needed to add -DCMAKE_POSITION_INDEPENDENT_CODE=ON to build on linux

### DIFF
--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -66,6 +66,7 @@ fn build_libheif() {
     }
     configure
         .arg("-DCMAKE_BUILD_TYPE=Release")
+        .arg("-DCMAKE_POSITION_INDEPENDENT_CODE=ON")
         .arg("-DBUILD_SHARED_LIBS=OFF")
         .arg("-DBUILD_DOCUMENTATION=OFF")
         .arg("-DBUILD_TESTING=OFF")
@@ -388,6 +389,7 @@ fn build_libjpeg(manifest_dir: &Path, out_dir: &Path, is_windows: bool) -> Optio
         }
         configure
             .arg("-DCMAKE_BUILD_TYPE=Release")
+            .arg("-DCMAKE_POSITION_INDEPENDENT_CODE=ON")
             .arg("-DENABLE_SHARED=FALSE")
             .arg("-DENABLE_STATIC=TRUE")
             .arg(source_dir.as_os_str())
@@ -467,6 +469,7 @@ fn build_libde265(
             configure.arg("-G").arg("Unix Makefiles");
         }
         configure
+            .arg("-DCMAKE_POSITION_INDEPENDENT_CODE=ON")
             .arg("-DBUILD_SHARED_LIBS=OFF")
             .arg("-DENABLE_SDL=OFF")
             .arg("-DENABLE_DECODER=ON")


### PR DESCRIPTION
I'm not really sure if the fix is good. That is beyond my knowledge it made the build work though and lap was running afterward.

Without these the build on linux failed with errors like:

```
rust-lld: error: relocation R_X86_64_64 cannot be used against local
symbol; recompile with -fPIC
>>> defined in
 /lap/src-tauri/target/debug/build/Lap-48f53136a0329abd/out/libjpeg-build/build/libjpeg.a(jdmerge-12.c.o)
>>> referenced by jdmerge-12.c
>>>               jdmerge-12.c.o:(.rodata+0x28) in archive
 /lap/src-tauri/target/debug/build/Lap-48f53136a0329abd/out/libjpeg-build/build/libjpeg.a
```