### PR TITLE
Add image reverse prompter

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -6,6 +6,7 @@
     "main",
     "imageviewer",
     "imageeditor",
+    "reverseprompter",
     "settings"
   ],
   "permissions": [

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -32,6 +32,7 @@ mod t_menu;
 mod t_migration;
 mod t_pasteboard;
 mod t_protocol;
+mod t_reverse_prompt;
 mod t_sqlite;
 mod t_utils;
 mod t_http;
@@ -342,6 +343,8 @@ async fn main() {
             t_video::prepare_video,
             t_video::cancel_video_prepare,
             t_video::clear_video_cache,
+            // reverse prompt
+            t_reverse_prompt::reverse_prompt_image,
             // backup / restore
             t_cmds::get_db_storage_info,
             t_cmds::backup_databases,

--- a/src-tauri/src/t_reverse_prompt.rs
+++ b/src-tauri/src/t_reverse_prompt.rs
@@ -1,0 +1,239 @@
+use reqwest::header::{ACCEPT, CONTENT_TYPE, USER_AGENT};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::time::Duration;
+
+const DEFAULT_REVERSE_PROMPT_ENDPOINT: &str = "https://api.openai.com/v1/responses";
+const DEFAULT_REVERSE_PROMPT_MODEL: &str = "gpt-5.5";
+const DEFAULT_REVERSE_PROMPT_INSTRUCTION: &str = "Describe this image as one reusable image-generation prompt. Include visible subject, environment, composition, lighting, color palette, style, mood, and camera or medium. Return one prompt only.";
+const MAX_IMAGE_DATA_URL_LEN: usize = 20_971_520;
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ReversePromptRequest {
+    api_key: String,
+    image_data_url: String,
+    model: Option<String>,
+    endpoint: Option<String>,
+    detail: Option<String>,
+    instruction: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ReversePromptResult {
+    prompt: String,
+}
+
+#[tauri::command]
+pub async fn reverse_prompt_image(
+    request: ReversePromptRequest,
+) -> Result<ReversePromptResult, String> {
+    let api_key = request.api_key.trim();
+    if api_key.is_empty() {
+        return Err("API key is required.".to_string());
+    }
+
+    let image_data_url = request.image_data_url.trim();
+    validate_image_data_url(image_data_url)?;
+
+    let endpoint = request
+        .endpoint
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or(DEFAULT_REVERSE_PROMPT_ENDPOINT);
+    let model = request
+        .model
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or(DEFAULT_REVERSE_PROMPT_MODEL);
+    let instruction = request
+        .instruction
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or(DEFAULT_REVERSE_PROMPT_INSTRUCTION);
+    let detail = normalize_detail(request.detail.as_deref())?;
+
+    let body = serde_json::json!({
+        "model": model,
+        "input": [
+            {
+                "role": "user",
+                "content": [
+                    { "type": "input_text", "text": instruction },
+                    {
+                        "type": "input_image",
+                        "image_url": image_data_url,
+                        "detail": detail,
+                    }
+                ]
+            }
+        ]
+    });
+
+    let client = reqwest::Client::builder()
+        .connect_timeout(Duration::from_secs(10))
+        .timeout(Duration::from_secs(90))
+        .build()
+        .map_err(|e| format!("Failed to create vision client: {}", e))?;
+
+    let response = client
+        .post(endpoint)
+        .bearer_auth(api_key)
+        .header(CONTENT_TYPE, "application/json")
+        .header(ACCEPT, "application/json")
+        .header(USER_AGENT, "Lap Reverse Prompter")
+        .body(body.to_string())
+        .send()
+        .await
+        .map_err(|e| format!("Vision request failed: {}", e))?;
+
+    let status = response.status();
+    let response_text = response
+        .text()
+        .await
+        .map_err(|e| format!("Failed to read vision response: {}", e))?;
+    let value: Value = serde_json::from_str(&response_text).map_err(|e| {
+        format!(
+            "Vision API returned non-JSON response ({}): {}",
+            status.as_u16(),
+            truncate_response(&format!("{}: {}", e, response_text))
+        )
+    })?;
+
+    if !status.is_success() {
+        let message = extract_api_error_message(&value)
+            .unwrap_or_else(|| format!("Vision API returned HTTP {}", status.as_u16()));
+        return Err(message);
+    }
+
+    Ok(ReversePromptResult {
+        prompt: extract_openai_output_text(&value)?,
+    })
+}
+
+fn validate_image_data_url(image_data_url: &str) -> Result<(), String> {
+    if image_data_url.len() > MAX_IMAGE_DATA_URL_LEN {
+        return Err("Image is too large for the vision API request.".to_string());
+    }
+
+    if !image_data_url.starts_with("data:image/") || !image_data_url.contains(";base64,") {
+        return Err("Image must be sent as a base64 image data URL.".to_string());
+    }
+
+    Ok(())
+}
+
+fn normalize_detail(detail: Option<&str>) -> Result<&'static str, String> {
+    match detail.unwrap_or("high").trim().to_ascii_lowercase().as_str() {
+        "" | "high" => Ok("high"),
+        "low" => Ok("low"),
+        "auto" => Ok("auto"),
+        "original" => Ok("original"),
+        other => Err(format!("Unsupported image detail level: {}", other)),
+    }
+}
+
+pub(crate) fn extract_openai_output_text(value: &Value) -> Result<String, String> {
+    if let Some(message) = extract_api_error_message(value) {
+        return Err(message);
+    }
+
+    if let Some(text) = value.get("output_text").and_then(Value::as_str) {
+        if let Some(cleaned) = clean_output_text(text) {
+            return Ok(cleaned);
+        }
+    }
+
+    if let Some(output) = value.get("output").and_then(Value::as_array) {
+        for item in output {
+            if let Some(content) = item.get("content").and_then(Value::as_array) {
+                for block in content {
+                    if let Some(text) = block.get("text").and_then(Value::as_str) {
+                        if let Some(cleaned) = clean_output_text(text) {
+                            return Ok(cleaned);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    if let Some(choices) = value.get("choices").and_then(Value::as_array) {
+        for choice in choices {
+            if let Some(text) = choice
+                .get("message")
+                .and_then(|message| message.get("content"))
+                .and_then(Value::as_str)
+            {
+                if let Some(cleaned) = clean_output_text(text) {
+                    return Ok(cleaned);
+                }
+            }
+        }
+    }
+
+    Err("Vision response did not include prompt text.".to_string())
+}
+
+fn extract_api_error_message(value: &Value) -> Option<String> {
+    value
+        .get("error")
+        .and_then(|error| error.get("message"))
+        .and_then(Value::as_str)
+        .and_then(clean_output_text)
+}
+
+fn clean_output_text(text: &str) -> Option<String> {
+    let cleaned = text.trim().trim_matches('"').trim();
+    if cleaned.is_empty() {
+        None
+    } else {
+        Some(cleaned.to_string())
+    }
+}
+
+fn truncate_response(text: &str) -> String {
+    const MAX_LEN: usize = 240;
+    if text.len() <= MAX_LEN {
+        return text.to_string();
+    }
+    format!("{}...", &text[..MAX_LEN])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::extract_openai_output_text;
+
+    #[test]
+    fn extracts_output_text_from_responses_api() {
+        let value = serde_json::json!({
+            "output": [
+                {
+                    "type": "message",
+                    "content": [
+                        { "type": "output_text", "text": "cinematic portrait prompt" }
+                    ]
+                }
+            ]
+        });
+
+        assert_eq!(
+            extract_openai_output_text(&value).unwrap(),
+            "cinematic portrait prompt"
+        );
+    }
+
+    #[test]
+    fn returns_api_error_message() {
+        let value = serde_json::json!({
+            "error": { "message": "invalid api key" }
+        });
+
+        let error = extract_openai_output_text(&value).unwrap_err();
+        assert!(error.contains("invalid api key"));
+    }
+}

--- a/src-vite/package.json
+++ b/src-vite/package.json
@@ -7,7 +7,8 @@
     "dev": "vite --config vite.config.js",
     "dev:clean": "vite --config vite.config.js --force",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test:reverse-prompt": "node --test src/common/reversePrompt.test.js"
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.2.2",

--- a/src-vite/src/common/api.js
+++ b/src-vite/src/common/api.js
@@ -952,6 +952,10 @@ export async function importClipboard(folderId, folderPath) {
   return await invoke('import_clipboard', { folderId, folderPath });
 }
 
+export async function reversePromptImage(request) {
+  return await invoke('reverse_prompt_image', { request });
+}
+
 export async function importFromDrag(folderId, folderPath) {
   try {
     const result = await invoke('import_from_drag', { folderId, folderPath });

--- a/src-vite/src/common/reversePrompt.js
+++ b/src-vite/src/common/reversePrompt.js
@@ -1,0 +1,124 @@
+export const DEFAULT_REVERSE_PROMPT_MODEL = 'gpt-5.5';
+export const DEFAULT_REVERSE_PROMPT_ENDPOINT = 'https://api.openai.com/v1/responses';
+
+const TONE_INSTRUCTIONS = {
+  concise: 'Keep it to one dense sentence with the most important visual details.',
+  detailed: 'Include subject, setting, composition, lighting, color palette, materials, style, mood, and camera or medium cues.',
+  tags: 'Use a compact comma-separated prompt with descriptive tags and no filler.',
+};
+
+const COMMON_RATIOS = [
+  { w: 1, h: 1, label: '1:1' },
+  { w: 4, h: 3, label: '4:3' },
+  { w: 3, h: 4, label: '3:4' },
+  { w: 3, h: 2, label: '3:2' },
+  { w: 2, h: 3, label: '2:3' },
+  { w: 16, h: 9, label: '16:9' },
+  { w: 9, h: 16, label: '9:16' },
+  { w: 21, h: 9, label: '21:9' },
+];
+
+export function buildReversePromptInstruction({ tone = 'detailed', extraContext = '' } = {}) {
+  const toneInstruction = TONE_INSTRUCTIONS[tone] || TONE_INSTRUCTIONS.detailed;
+  const context = String(extraContext || '').trim();
+
+  return [
+    'Describe this image as a reusable image-generation prompt.',
+    'Focus on the visible subject, environment, composition, lighting, color palette, textures, style, mood, and camera or medium.',
+    toneInstruction,
+    'Return one prompt only. Do not include bullet points, labels, markdown, or explanations.',
+    context ? `Additional intent: ${context}` : '',
+  ].filter(Boolean).join(' ');
+}
+
+export function buildFallbackPrompt(analysis = {}) {
+  const width = toPositiveInt(analysis.width);
+  const height = toPositiveInt(analysis.height);
+  const dimension = width && height ? `${width}x${height}` : '';
+  const ratio = width && height ? getAspectRatioLabel(width, height) : '';
+  const orientation = width && height ? getOrientationLabel(width, height) : '';
+  const base = [orientation, ratio, 'image'].filter(Boolean).join(' ');
+  const format = getFormatLabel(analysis.mimeType);
+  const qualities = [
+    analysis.hasAlpha ? 'transparent background support' : '',
+    getBrightnessLabel(analysis.averageBrightness),
+    getContrastLabel(analysis.contrast),
+    getSaturationLabel(analysis.averageSaturation),
+  ].filter(Boolean);
+  const palette = normalizePalette(analysis.palette);
+
+  const parts = [
+    base || 'image',
+    dimension,
+    format,
+    ...qualities,
+    palette.length ? `dominant palette ${palette.join(', ')}` : '',
+    'clean composition',
+    'clear visual hierarchy',
+    'suitable as a reusable image-generation prompt',
+  ].filter(Boolean);
+
+  return `${parts.join(', ')}.`;
+}
+
+export function normalizePalette(palette = []) {
+  if (!Array.isArray(palette)) return [];
+
+  return palette
+    .map((color) => String(color || '').trim().toLowerCase())
+    .filter((color) => /^#[0-9a-f]{6}$/.test(color))
+    .slice(0, 5);
+}
+
+function toPositiveInt(value) {
+  const number = Number(value);
+  if (!Number.isFinite(number) || number <= 0) return 0;
+  return Math.round(number);
+}
+
+function getAspectRatioLabel(width, height) {
+  const actual = width / height;
+  for (const ratio of COMMON_RATIOS) {
+    if (Math.abs(actual - ratio.w / ratio.h) < 0.015) {
+      return ratio.label;
+    }
+  }
+  return `${actual.toFixed(2)}:1`;
+}
+
+function getOrientationLabel(width, height) {
+  const ratio = width / height;
+  if (ratio > 1.18) return 'wide';
+  if (ratio < 0.85) return 'vertical';
+  return 'square';
+}
+
+function getFormatLabel(mimeType) {
+  const mime = String(mimeType || '').toLowerCase();
+  if (!mime.startsWith('image/')) return '';
+  return `${mime.slice('image/'.length).toUpperCase()} source`;
+}
+
+function getBrightnessLabel(value) {
+  const number = Number(value);
+  if (!Number.isFinite(number)) return '';
+  if (number >= 0.67) return 'bright exposure';
+  if (number <= 0.33) return 'dark exposure';
+  return 'balanced exposure';
+}
+
+function getContrastLabel(value) {
+  const number = Number(value);
+  if (!Number.isFinite(number)) return '';
+  if (number >= 0.35) return 'high-contrast';
+  if (number <= 0.16) return 'soft contrast';
+  return 'moderate contrast';
+}
+
+function getSaturationLabel(value) {
+  const number = Number(value);
+  if (!Number.isFinite(number)) return '';
+  if (number >= 0.58) return 'saturated color';
+  if (number <= 0.24) return 'muted color';
+  return 'natural color';
+}

--- a/src-vite/src/common/reversePrompt.test.js
+++ b/src-vite/src/common/reversePrompt.test.js
@@ -1,0 +1,44 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  buildFallbackPrompt,
+  buildReversePromptInstruction,
+} from './reversePrompt.js';
+
+test('buildReversePromptInstruction asks for a reusable prompt only', () => {
+  const instruction = buildReversePromptInstruction({
+    tone: 'detailed',
+    extraContext: 'Match a cinematic product photography style.',
+  });
+
+  assert.match(instruction, /reusable image-generation prompt/i);
+  assert.match(instruction, /subject/i);
+  assert.match(instruction, /lighting/i);
+  assert.match(instruction, /one prompt only/i);
+  assert.match(instruction, /cinematic product photography/i);
+});
+
+test('buildFallbackPrompt summarizes format, dimensions, color, and visual qualities', () => {
+  const prompt = buildFallbackPrompt({
+    fileName: 'studio-watch.png',
+    width: 1600,
+    height: 900,
+    mimeType: 'image/png',
+    sizeBytes: 2_400_000,
+    hasAlpha: true,
+    averageBrightness: 0.72,
+    averageSaturation: 0.68,
+    contrast: 0.42,
+    palette: ['#0f172a', '#f59e0b', '#f8fafc'],
+  });
+
+  assert.match(prompt, /wide 16:9/i);
+  assert.match(prompt, /1600x900/i);
+  assert.match(prompt, /transparent/i);
+  assert.match(prompt, /bright/i);
+  assert.match(prompt, /high-contrast/i);
+  assert.match(prompt, /saturated/i);
+  assert.match(prompt, /#0f172a, #f59e0b, #f8fafc/i);
+  assert.doesNotMatch(prompt, /undefined|null|NaN/);
+});

--- a/src-vite/src/common/reversePrompt.test.js
+++ b/src-vite/src/common/reversePrompt.test.js
@@ -1,5 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
 
 import {
   buildFallbackPrompt,
@@ -41,4 +42,19 @@ test('buildFallbackPrompt summarizes format, dimensions, color, and visual quali
   assert.match(prompt, /saturated/i);
   assert.match(prompt, /#0f172a, #f59e0b, #f8fafc/i);
   assert.doesNotMatch(prompt, /undefined|null|NaN/);
+});
+
+test('reverse prompter view shows its hidden Tauri window after mount', async () => {
+  const source = await readFile(new URL('../views/ReversePrompter.vue', import.meta.url), 'utf8');
+
+  assert.match(source, /getCurrentWebviewWindow/);
+  assert.match(source, /const\s+appWindow\s*=\s*getCurrentWebviewWindow\(\)/);
+  assert.match(source, /onMounted\(\s*async\s*\(\)\s*=>[\s\S]*await\s+appWindow\.show\(\)/);
+});
+
+test('tauri capabilities allow the reverse prompter window label', async () => {
+  const source = await readFile(new URL('../../../src-tauri/capabilities/default.json', import.meta.url), 'utf8');
+  const capabilities = JSON.parse(source);
+
+  assert.ok(capabilities.windows.includes('reverseprompter'));
 });

--- a/src-vite/src/common/router.js
+++ b/src-vite/src/common/router.js
@@ -18,6 +18,11 @@ const routes = [
     component: () => import('@/views/ImageEditor.vue'),
   },
   {
+    path: '/reverse-prompter',
+    name: 'ReversePrompter',
+    component: () => import('@/views/ReversePrompter.vue'),
+  },
+  {
     path: '/settings',
     name: 'Settings',
     component: () => import('@/views/Settings.vue'),

--- a/src-vite/src/locales/en.json
+++ b/src-vite/src/locales/en.json
@@ -9,6 +9,7 @@
     "location": "Location",
     "people": "People",
     "camera": "Cameras",
+    "reverse_prompt": "Reverse Prompter",
     "settings": "Settings"
   },
   "album": {

--- a/src-vite/src/views/Home.vue
+++ b/src-vite/src/views/Home.vue
@@ -53,6 +53,14 @@
 
             <div class="flex-1"></div>
 
+            <TButton
+              :buttonSize="'large'"
+              :icon="IconSmartTag"
+              :text="reversePrompterLabel"
+              :tooltip="reversePrompterTitle"
+              @click="clickReversePrompter"
+            />
+
             <TButton 
               class="mt-auto"
               :class="showDebugBadge ? 'text-warning': ''"
@@ -199,6 +207,7 @@ import {
   IconArrowDown,
   IconCalendarDay,
   IconPhotoAll,
+  IconSmartTag,
 } from '@/common/icons';
 
 const isSwitchingLibrary = ref(false);
@@ -218,10 +227,14 @@ const checkLibraryEmpty = async () => {
 };
 const SETTINGS_BASE_WIDTH = 600;
 const SETTINGS_BASE_HEIGHT = 620;
+const REVERSE_PROMPTER_BASE_WIDTH = 1040;
+const REVERSE_PROMPTER_BASE_HEIGHT = 720;
 
 /// i18n
 const { locale, messages } = useI18n();
 const localeMsg = computed(() => messages.value[locale.value] as any);
+const reversePrompterTitle = computed(() => localeMsg.value.sidebar?.reverse_prompt || 'Reverse Prompter');
+const reversePrompterLabel = computed(() => config.settings.showButtonText ? reversePrompterTitle.value : '');
 
 const uiStore = useUIStore();
 
@@ -619,6 +632,46 @@ async function clickSettings(tabIndex?: number) {
   newSettingsWindow.once('tauri://close-requested', () => {
     newSettingsWindow.close();
     console.log('settings window closed');
+  });
+}
+
+async function clickReversePrompter() {
+  const existingWindow = await WebviewWindow.getByLabel('reverseprompter');
+  if (existingWindow) {
+    if (isWin && await existingWindow.isMinimized()) {
+      await existingWindow.unminimize();
+    }
+    await existingWindow.show();
+    if (isWin) {
+      await existingWindow.setFocus();
+    }
+    return;
+  }
+
+  const options: any = {
+    url: '/reverse-prompter',
+    title: reversePrompterTitle.value,
+    width: Math.round(REVERSE_PROMPTER_BASE_WIDTH * getSettingsWindowScale()),
+    height: Math.round(REVERSE_PROMPTER_BASE_HEIGHT * getSettingsWindowScale()),
+    minWidth: Math.round(720 * getSettingsWindowScale()),
+    minHeight: Math.round(520 * getSettingsWindowScale()),
+    resizable: true,
+    maximizable: true,
+    visible: false,
+    transparent: true,
+    decorations: isMac,
+    ...(isMac && {
+      titleBarStyle: 'Overlay',
+      hiddenTitle: true,
+    }),
+  };
+
+  const reverseWindow = new WebviewWindow('reverseprompter', options);
+  reverseWindow.once('tauri://created', () => {
+    console.log('reverse prompter window created');
+  });
+  reverseWindow.once('tauri://close-requested', () => {
+    reverseWindow.close();
   });
 }
 

--- a/src-vite/src/views/ReversePrompter.vue
+++ b/src-vite/src/views/ReversePrompter.vue
@@ -1,0 +1,547 @@
+<template>
+  <div
+    class="w-screen h-screen flex flex-col overflow-hidden select-none bg-base-300 text-base-content/70"
+    @dragenter.prevent="isDragging = true"
+    @dragover.prevent="isDragging = true"
+    @dragleave.prevent="isDragging = false"
+    @drop.prevent="handleDrop"
+  >
+    <TitleBar titlebar="Reverse Prompter" viewName="ReversePrompter" class="shrink-0 z-50" />
+
+    <main class="reverse-prompter-layout flex-1 min-h-0 p-2 gap-2">
+      <section class="min-h-0 flex flex-col overflow-hidden rounded-box bg-base-200">
+        <div class="h-11 px-3 shrink-0 flex items-center gap-2 border-b border-base-content/10" data-tauri-drag-region>
+          <IconSmartTag class="w-5 h-5 text-primary shrink-0" />
+          <span class="font-medium truncate">Image</span>
+          <div class="flex-1" data-tauri-drag-region></div>
+          <button class="btn btn-sm btn-ghost rounded-box gap-2" @click="selectFile">
+            <IconUpload class="w-4 h-4" />
+            <span>Select</span>
+          </button>
+          <button class="btn btn-sm btn-ghost rounded-box gap-2" :disabled="!previewUrl" @click="clearImage">
+            <IconClose class="w-4 h-4" />
+            <span>Clear</span>
+          </button>
+        </div>
+
+        <button
+          class="relative flex-1 min-h-0 m-2 rounded-box overflow-hidden border border-dashed transition-colors bg-base-300/50"
+          :class="isDragging ? 'border-primary text-primary' : 'border-base-content/15 hover:border-base-content/30'"
+          @click="selectFile"
+        >
+          <img
+            v-if="previewUrl"
+            :src="previewUrl"
+            class="absolute inset-0 w-full h-full object-contain"
+            draggable="false"
+            alt=""
+          />
+          <div v-else class="absolute inset-0 flex flex-col items-center justify-center gap-3 text-base-content/45">
+            <IconDragDrop class="w-12 h-12" />
+            <div class="text-sm font-medium">Paste / drop / select</div>
+          </div>
+        </button>
+
+        <div class="shrink-0 p-3 grid grid-cols-2 gap-2 border-t border-base-content/10">
+          <div v-for="item in metadataItems" :key="item.label" class="min-w-0 rounded-box bg-base-300/50 px-3 py-2">
+            <div class="text-[10px] uppercase font-bold text-base-content/35">{{ item.label }}</div>
+            <div class="truncate text-sm text-base-content/75" :title="item.value">{{ item.value }}</div>
+          </div>
+        </div>
+      </section>
+
+      <section class="min-h-0 flex flex-col overflow-hidden rounded-box bg-base-200">
+        <div class="h-11 px-3 shrink-0 flex items-center gap-2 border-b border-base-content/10" data-tauri-drag-region>
+          <IconComment class="w-5 h-5 text-primary shrink-0" />
+          <span class="font-medium truncate">Prompt</span>
+          <div class="flex-1" data-tauri-drag-region></div>
+          <button class="btn btn-sm btn-primary rounded-box gap-2" :disabled="!canGenerate" @click="generatePrompt">
+            <span v-if="isGenerating" class="loading loading-spinner loading-xs"></span>
+            <IconRefresh v-else class="w-4 h-4" />
+            <span>Generate</span>
+          </button>
+          <button class="btn btn-sm btn-ghost rounded-box gap-2" :disabled="!promptText" @click="copyPrompt">
+            <IconCopy class="w-4 h-4" />
+            <span>Copy</span>
+          </button>
+        </div>
+
+        <div class="shrink-0 p-3 grid gap-2 border-b border-base-content/10 reverse-prompter-controls">
+          <label class="form-control min-w-0">
+            <span class="label-text text-xs text-base-content/50">API key</span>
+            <input
+              v-model="apiKey"
+              type="password"
+              class="input input-sm input-bordered rounded-box w-full"
+              autocomplete="off"
+              placeholder="sk-..."
+            />
+          </label>
+          <label class="form-control min-w-0">
+            <span class="label-text text-xs text-base-content/50">Model</span>
+            <input v-model="model" class="input input-sm input-bordered rounded-box w-full" />
+          </label>
+          <label class="form-control min-w-0">
+            <span class="label-text text-xs text-base-content/50">Detail</span>
+            <select v-model="detail" class="select select-sm select-bordered rounded-box w-full">
+              <option value="high">High</option>
+              <option value="low">Low</option>
+              <option value="auto">Auto</option>
+              <option value="original">Original</option>
+            </select>
+          </label>
+          <label class="form-control min-w-0">
+            <span class="label-text text-xs text-base-content/50">Mode</span>
+            <select v-model="tone" class="select select-sm select-bordered rounded-box w-full">
+              <option value="detailed">Detailed</option>
+              <option value="concise">Concise</option>
+              <option value="tags">Tags</option>
+            </select>
+          </label>
+          <label class="form-control min-w-0 reverse-prompter-endpoint">
+            <span class="label-text text-xs text-base-content/50">Endpoint</span>
+            <input v-model="endpoint" class="input input-sm input-bordered rounded-box w-full" />
+          </label>
+        </div>
+
+        <div class="flex-1 min-h-0 p-3 grid gap-3 reverse-prompter-output">
+          <label class="form-control min-h-0">
+            <span class="label-text text-xs text-base-content/50">Intent</span>
+            <textarea
+              v-model="extraContext"
+              class="textarea textarea-bordered rounded-box min-h-18 resize-none"
+              placeholder="Optional"
+            ></textarea>
+          </label>
+
+          <label class="form-control min-h-0 flex-1">
+            <span class="label-text text-xs text-base-content/50">Output</span>
+            <textarea
+              v-model="promptText"
+              class="textarea textarea-bordered rounded-box h-full min-h-48 resize-none font-mono text-sm leading-6"
+              spellcheck="false"
+            ></textarea>
+          </label>
+        </div>
+
+        <div class="h-9 shrink-0 px-3 flex items-center gap-2 border-t border-base-content/10 text-xs">
+          <span class="w-2 h-2 rounded-full" :class="statusDotClass"></span>
+          <span class="truncate" :title="statusText">{{ statusText }}</span>
+        </div>
+      </section>
+    </main>
+
+    <input
+      ref="fileInputRef"
+      class="hidden"
+      type="file"
+      accept="image/*"
+      @change="handleFileSelection"
+    />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, onBeforeUnmount, onMounted, ref } from 'vue';
+import TitleBar from '@/components/TitleBar.vue';
+import { reversePromptImage } from '@/common/api';
+import {
+  DEFAULT_REVERSE_PROMPT_ENDPOINT,
+  DEFAULT_REVERSE_PROMPT_MODEL,
+  buildFallbackPrompt,
+  buildReversePromptInstruction,
+} from '@/common/reversePrompt';
+import {
+  IconClose,
+  IconComment,
+  IconCopy,
+  IconDragDrop,
+  IconRefresh,
+  IconSmartTag,
+  IconUpload,
+} from '@/common/icons';
+
+type ImageAnalysis = {
+  fileName: string;
+  width: number;
+  height: number;
+  mimeType: string;
+  sizeBytes: number;
+  hasAlpha: boolean;
+  averageBrightness: number;
+  averageSaturation: number;
+  contrast: number;
+  palette: string[];
+};
+
+const fileInputRef = ref<HTMLInputElement | null>(null);
+const previewUrl = ref('');
+const imageDataUrl = ref('');
+const imageInfo = ref<ImageAnalysis | null>(null);
+const promptText = ref('');
+const localPrompt = ref('');
+const apiKey = ref('');
+const model = ref(DEFAULT_REVERSE_PROMPT_MODEL);
+const endpoint = ref(DEFAULT_REVERSE_PROMPT_ENDPOINT);
+const detail = ref('high');
+const tone = ref('detailed');
+const extraContext = ref('');
+const statusText = ref('Ready');
+const statusKind = ref<'idle' | 'ok' | 'error' | 'loading'>('idle');
+const isGenerating = ref(false);
+const isDragging = ref(false);
+
+const canGenerate = computed(() => Boolean(imageDataUrl.value) && !isGenerating.value);
+const statusDotClass = computed(() => ({
+  'bg-base-content/30': statusKind.value === 'idle',
+  'bg-success': statusKind.value === 'ok',
+  'bg-error': statusKind.value === 'error',
+  'bg-primary animate-pulse': statusKind.value === 'loading',
+}));
+
+const metadataItems = computed(() => {
+  const info = imageInfo.value;
+  if (!info) {
+    return [
+      { label: 'Dimensions', value: '-' },
+      { label: 'Type', value: '-' },
+      { label: 'Size', value: '-' },
+      { label: 'Palette', value: '-' },
+    ];
+  }
+
+  return [
+    { label: 'Dimensions', value: `${info.width}x${info.height}` },
+    { label: 'Type', value: info.mimeType || 'image' },
+    { label: 'Size', value: formatBytes(info.sizeBytes) },
+    { label: 'Palette', value: info.palette.join(', ') || '-' },
+  ];
+});
+
+onMounted(() => {
+  window.addEventListener('paste', handlePaste);
+});
+
+onBeforeUnmount(() => {
+  window.removeEventListener('paste', handlePaste);
+  revokePreviewUrl();
+});
+
+function selectFile() {
+  fileInputRef.value?.click();
+}
+
+function handleFileSelection(event: Event) {
+  const input = event.target as HTMLInputElement;
+  const file = input.files?.[0];
+  if (file) {
+    void loadImageFile(file);
+  }
+  input.value = '';
+}
+
+function handlePaste(event: ClipboardEvent) {
+  const file = findImageFile(event.clipboardData?.items);
+  if (!file) return;
+  event.preventDefault();
+  void loadImageFile(file);
+}
+
+function handleDrop(event: DragEvent) {
+  isDragging.value = false;
+  const file = Array.from(event.dataTransfer?.files || []).find((item) => item.type.startsWith('image/'));
+  if (!file) {
+    setStatus('No image found in drop.', 'error');
+    return;
+  }
+  void loadImageFile(file);
+}
+
+async function loadImageFile(file: File) {
+  if (!file.type.startsWith('image/')) {
+    setStatus('Unsupported file type.', 'error');
+    return;
+  }
+
+  setStatus('Loading image...', 'loading');
+  const objectUrl = URL.createObjectURL(file);
+
+  try {
+    const image = await loadHtmlImage(objectUrl);
+    const analysis = analyzeImage(image, file);
+    const preparedDataUrl = prepareImageDataUrl(image, analysis.hasAlpha);
+
+    revokePreviewUrl();
+    previewUrl.value = objectUrl;
+    imageDataUrl.value = preparedDataUrl;
+    imageInfo.value = analysis;
+    localPrompt.value = buildFallbackPrompt(analysis);
+    promptText.value = localPrompt.value;
+    setStatus('Local prompt ready.', 'ok');
+  } catch (error) {
+    URL.revokeObjectURL(objectUrl);
+    setStatus(normalizeError(error), 'error');
+  }
+}
+
+async function generatePrompt() {
+  if (!imageDataUrl.value) {
+    setStatus('No image selected.', 'error');
+    return;
+  }
+
+  if (!apiKey.value.trim()) {
+    promptText.value = localPrompt.value;
+    setStatus('Local prompt ready.', 'ok');
+    return;
+  }
+
+  isGenerating.value = true;
+  setStatus('Generating prompt...', 'loading');
+
+  try {
+    const result = await reversePromptImage({
+      apiKey: apiKey.value.trim(),
+      imageDataUrl: imageDataUrl.value,
+      model: model.value.trim() || DEFAULT_REVERSE_PROMPT_MODEL,
+      endpoint: endpoint.value.trim() || DEFAULT_REVERSE_PROMPT_ENDPOINT,
+      detail: detail.value,
+      instruction: buildReversePromptInstruction({
+        tone: tone.value,
+        extraContext: extraContext.value,
+      }),
+    });
+
+    promptText.value = String(result?.prompt || '').trim();
+    setStatus('AI prompt ready.', 'ok');
+  } catch (error) {
+    if (localPrompt.value) {
+      promptText.value = localPrompt.value;
+    }
+    setStatus(normalizeError(error), 'error');
+  } finally {
+    isGenerating.value = false;
+  }
+}
+
+async function copyPrompt() {
+  if (!promptText.value) return;
+
+  try {
+    await navigator.clipboard.writeText(promptText.value);
+    setStatus('Prompt copied.', 'ok');
+  } catch (error) {
+    setStatus(normalizeError(error), 'error');
+  }
+}
+
+function clearImage() {
+  revokePreviewUrl();
+  imageDataUrl.value = '';
+  imageInfo.value = null;
+  promptText.value = '';
+  localPrompt.value = '';
+  setStatus('Ready', 'idle');
+}
+
+function findImageFile(items?: DataTransferItemList | null) {
+  if (!items) return null;
+
+  for (const item of Array.from(items)) {
+    if (item.kind === 'file' && item.type.startsWith('image/')) {
+      return item.getAsFile();
+    }
+  }
+
+  return null;
+}
+
+function loadHtmlImage(src: string): Promise<HTMLImageElement> {
+  return new Promise((resolve, reject) => {
+    const image = new Image();
+    image.onload = () => resolve(image);
+    image.onerror = () => reject(new Error('Image could not be decoded.'));
+    image.src = src;
+  });
+}
+
+function analyzeImage(image: HTMLImageElement, file: File): ImageAnalysis {
+  const canvas = document.createElement('canvas');
+  const sampleSize = 72;
+  canvas.width = sampleSize;
+  canvas.height = sampleSize;
+  const context = canvas.getContext('2d', { willReadFrequently: true });
+  if (!context) {
+    throw new Error('Canvas is not available.');
+  }
+
+  context.drawImage(image, 0, 0, sampleSize, sampleSize);
+  const pixels = context.getImageData(0, 0, sampleSize, sampleSize).data;
+  const paletteCounts = new Map<string, number>();
+  const luminanceValues: number[] = [];
+  let brightnessTotal = 0;
+  let saturationTotal = 0;
+  let opaqueCount = 0;
+  let transparentCount = 0;
+
+  for (let index = 0; index < pixels.length; index += 4) {
+    const alpha = pixels[index + 3];
+    if (alpha < 250) {
+      transparentCount++;
+    }
+    if (alpha < 32) {
+      continue;
+    }
+
+    const red = pixels[index];
+    const green = pixels[index + 1];
+    const blue = pixels[index + 2];
+    const luminance = (0.2126 * red + 0.7152 * green + 0.0722 * blue) / 255;
+    const saturation = getRgbSaturation(red, green, blue);
+    const key = quantizeHex(red, green, blue);
+
+    brightnessTotal += luminance;
+    saturationTotal += saturation;
+    luminanceValues.push(luminance);
+    paletteCounts.set(key, (paletteCounts.get(key) || 0) + 1);
+    opaqueCount++;
+  }
+
+  const count = Math.max(opaqueCount, 1);
+  const averageBrightness = brightnessTotal / count;
+  const contrast = Math.sqrt(
+    luminanceValues.reduce((total, value) => total + (value - averageBrightness) ** 2, 0) / count
+  );
+
+  return {
+    fileName: file.name,
+    width: image.naturalWidth || image.width,
+    height: image.naturalHeight || image.height,
+    mimeType: file.type,
+    sizeBytes: file.size,
+    hasAlpha: transparentCount > sampleSize * sampleSize * 0.01,
+    averageBrightness,
+    averageSaturation: saturationTotal / count,
+    contrast,
+    palette: Array.from(paletteCounts.entries())
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, 5)
+      .map(([color]) => color),
+  };
+}
+
+function prepareImageDataUrl(image: HTMLImageElement, hasAlpha: boolean) {
+  const sourceWidth = image.naturalWidth || image.width;
+  const sourceHeight = image.naturalHeight || image.height;
+  let maxDimension = 2048;
+  let quality = 0.92;
+  let latestDataUrl = '';
+
+  for (let attempt = 0; attempt < 4; attempt++) {
+    const scale = Math.min(1, maxDimension / Math.max(sourceWidth, sourceHeight));
+    const width = Math.max(1, Math.round(sourceWidth * scale));
+    const height = Math.max(1, Math.round(sourceHeight * scale));
+    const canvas = document.createElement('canvas');
+    canvas.width = width;
+    canvas.height = height;
+    const context = canvas.getContext('2d');
+    if (!context) {
+      throw new Error('Canvas is not available.');
+    }
+
+    if (!hasAlpha) {
+      context.fillStyle = '#ffffff';
+      context.fillRect(0, 0, width, height);
+    }
+    context.drawImage(image, 0, 0, width, height);
+
+    latestDataUrl = hasAlpha
+      ? canvas.toDataURL('image/png')
+      : canvas.toDataURL('image/jpeg', quality);
+    if (latestDataUrl.length < 19_500_000) {
+      return latestDataUrl;
+    }
+
+    maxDimension = Math.round(maxDimension * 0.75);
+    quality = Math.max(0.78, quality - 0.06);
+  }
+
+  return latestDataUrl;
+}
+
+function getRgbSaturation(red: number, green: number, blue: number) {
+  const max = Math.max(red, green, blue) / 255;
+  const min = Math.min(red, green, blue) / 255;
+  if (max <= 0) return 0;
+  return (max - min) / max;
+}
+
+function quantizeHex(red: number, green: number, blue: number) {
+  const quantize = (value: number) => Math.max(0, Math.min(255, Math.round(value / 32) * 32));
+  return `#${toHex(quantize(red))}${toHex(quantize(green))}${toHex(quantize(blue))}`;
+}
+
+function toHex(value: number) {
+  return value.toString(16).padStart(2, '0');
+}
+
+function revokePreviewUrl() {
+  if (previewUrl.value) {
+    URL.revokeObjectURL(previewUrl.value);
+    previewUrl.value = '';
+  }
+}
+
+function setStatus(text: string, kind: 'idle' | 'ok' | 'error' | 'loading') {
+  statusText.value = text;
+  statusKind.value = kind;
+}
+
+function normalizeError(error: unknown) {
+  if (typeof error === 'string') return error;
+  if (error instanceof Error) return error.message;
+  return 'Request failed.';
+}
+
+function formatBytes(bytes: number) {
+  if (!Number.isFinite(bytes) || bytes <= 0) return '-';
+  const units = ['B', 'KB', 'MB', 'GB'];
+  let value = bytes;
+  let unitIndex = 0;
+  while (value >= 1024 && unitIndex < units.length - 1) {
+    value /= 1024;
+    unitIndex++;
+  }
+  return `${value.toFixed(unitIndex === 0 ? 0 : 1)} ${units[unitIndex]}`;
+}
+</script>
+
+<style scoped>
+.reverse-prompter-layout {
+  display: grid;
+  grid-template-columns: minmax(320px, 0.85fr) minmax(440px, 1.15fr);
+}
+
+.reverse-prompter-controls {
+  grid-template-columns: minmax(180px, 1.2fr) minmax(120px, 0.8fr) minmax(96px, 0.45fr) minmax(104px, 0.45fr);
+}
+
+.reverse-prompter-endpoint {
+  grid-column: 1 / -1;
+}
+
+.reverse-prompter-output {
+  grid-template-rows: auto minmax(0, 1fr);
+}
+
+@media (max-width: 900px) {
+  .reverse-prompter-layout {
+    grid-template-columns: minmax(0, 1fr);
+    grid-template-rows: minmax(240px, 42%) minmax(360px, 1fr);
+  }
+
+  .reverse-prompter-controls {
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  }
+}
+</style>

--- a/src-vite/src/views/ReversePrompter.vue
+++ b/src-vite/src/views/ReversePrompter.vue
@@ -143,6 +143,7 @@
 
 <script setup lang="ts">
 import { computed, onBeforeUnmount, onMounted, ref } from 'vue';
+import { getCurrentWebviewWindow } from '@tauri-apps/api/webviewWindow';
 import TitleBar from '@/components/TitleBar.vue';
 import { reversePromptImage } from '@/common/api';
 import {
@@ -190,6 +191,7 @@ const statusText = ref('Ready');
 const statusKind = ref<'idle' | 'ok' | 'error' | 'loading'>('idle');
 const isGenerating = ref(false);
 const isDragging = ref(false);
+const appWindow = getCurrentWebviewWindow();
 
 const canGenerate = computed(() => Boolean(imageDataUrl.value) && !isGenerating.value);
 const statusDotClass = computed(() => ({
@@ -218,8 +220,9 @@ const metadataItems = computed(() => {
   ];
 });
 
-onMounted(() => {
+onMounted(async () => {
   window.addEventListener('paste', handlePaste);
+  await appWindow.show();
 });
 
 onBeforeUnmount(() => {


### PR DESCRIPTION
## Summary
- Add a Reverse Prompter tool window with paste/drop/select image input.
- Add local image analysis fallback prompt generation for offline/no-key use.
- Add an OpenAI-compatible Tauri vision command for API-backed image-to-prompt generation.
- Address review findings by showing the hidden reverse prompter window after mount and allowing its Tauri window label in default capabilities.

## Verification
- `pnpm test:reverse-prompt` — passed, 4/4 tests.
- `pnpm build` — passed; Vite emitted the existing large-chunk warning.
- `cargo check --bin Lap --message-format short` — passed.
- `cargo test t_reverse_prompt` — passed, 2/2 tests.
- `Invoke-WebRequest http://localhost:3581/reverse-prompter` — returned HTTP 200 from the worktree dev server.

## Notes
- Browser visual smoke not run: no connected `iab` or Chrome browser backend in this Codex session.
- No changelog fragment added; this repo does not appear to have a changelog-fragment gate.