### PR TITLE
feat/close_mediaViewer_on_backdrop_click

### DIFF
--- a/src-vite/src/components/MediaViewer.vue
+++ b/src-vite/src/components/MediaViewer.vue
@@ -301,6 +301,7 @@
         @scale="(e) => $emit('scale', e)"
         @viewport-change="(e) => $emit('viewport-change', e)"
         @message-from-image-viewer="handleMessageFromImageViewer"
+        @click.self.stop="handleOverlayClick"
       ></Image>
       
       <Video v-if="file?.file_type === 2"
@@ -824,11 +825,19 @@ const handleZoomOut = () => {
   zoomOut();
 };
 
+const handleOverlayClick = () =>{
+  if(props.mode === 0){
+    emit('close')
+  }
+}
+
 const handleMessageFromImageViewer = (payload: { message: string }) => {
   if (payload.message === 'prev') {
     triggerPrev();
   } else if (payload.message === 'next') {
     triggerNext();
+  } else if (payload.message === 'close') {
+    handleOverlayClick();
   }
 };
 

--- a/src-vite/src/components/Video.vue
+++ b/src-vite/src/components/Video.vue
@@ -82,6 +82,7 @@ const noTransition = ref(false);
 const activeVideo = ref(0);
 let currentLoadingId = 0;
 const loadAttemptCleanups: Array<(() => void) | null> = [null, null];
+const videoClickCleanups = ref<Array<(() => void) | null>>([null, null]);
 
 const externalVideoAppPath = computed(() => String(config.settings?.externalVideoAppPath || '').trim());
 const externalVideoAppName = computed(() => String(config.settings?.externalVideoAppName || '').trim());
@@ -269,6 +270,22 @@ const setupPlayer = (index: number) => {
       if (activeVideo.value === index && !isLoading.value) {
         config.setVideoVolume(player.volume());
         config.setVideoMuted(player.muted());
+      }
+    });
+
+    player.ready(() => {
+      const videoEl = player.el();
+      if (videoEl) {
+        const clickHandler = (e: Event) => {
+          if (e.target !== e.currentTarget) {
+            return; // Exit early, allowing the child element to function normally
+          }
+          e.stopPropagation();
+          emit('message-from-video-viewer', { message: 'close' });
+        };
+        videoEl.addEventListener('click', clickHandler, false);
+        const cleanup = () => videoEl.removeEventListener('click', clickHandler, false);
+        videoClickCleanups.value[index] = cleanup;
       }
     });
   }
@@ -670,6 +687,7 @@ onBeforeUnmount(() => {
     }
   });
   loadAttemptCleanups.forEach((cleanup) => cleanup?.());
+  videoClickCleanups.value.forEach(cleanup => cleanup?.());
   players.value = [null, null];
   cancelVideoPrepare('0');
   cancelVideoPrepare('1');


### PR DESCRIPTION
As a user of lap i needed a faster way to dismiss/close the media viewer during quick previews without aiming for the close button or using keys.
**Solution**: Added a click listener to the media viewer backdrop that emits a close event.

**Features**:
- Enables dismissing/closing the media viewer by clicking the background/backdrop.
- Restricts this behavior exclusively to quick view mode(0), preserving standard interactions in full viewing modes.
- Ensures clicks on the media itself or its controls do not trigger the close action.

