### PR TITLE
fix: thumbnail_ready handler crash on null placeholder items

### DIFF
--- a/src-vite/src/components/Content.vue
+++ b/src-vite/src/components/Content.vue
@@ -4355,7 +4355,7 @@ onMounted( async() => {
     if (readyIds.size === 0) return;
 
     const loadedFiles = fileList.value.filter(
-      (file: any) => !file?.isPlaceholder && readyIds.has(Number(file.id || 0))
+      (file: any) => file && !file.isPlaceholder && readyIds.has(Number(file.id || 0))
     );
     if (loadedFiles.length === 0) return;
 


### PR DESCRIPTION
Problem
---

After refreshing file info, thumbnails show blank until the user scrolls. Scrolling to the bottom of the album restores normal behavior for all subsequent refreshes. Affects all file types (JPG, RAW).

Root Cause
---

The `thumbnail_ready` event handler iterates `fileList.value`, which contains null placeholder items from virtual scroll's lazy loading. The filter `!file?.isPlaceholder` evaluates to `true` for null (since `undefined` is falsy, `!undefined` is `true`), then `file.id` throws `TypeError`, crashing the entire handler. `getFileListThumb` is never called, so thumbnails stay blank.

Scrolling to the bottom replaces all null placeholders with actual file data, after which the handler works normally.

Fix
---

Add `file &&` null guard at the start of the filter callback to skip null placeholder items.